### PR TITLE
Adds Descriptor with Created timestamp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ toolchain go1.23.5
 
 require (
 	github.com/google/go-containerregistry v0.20.3
+	github.com/gpustack/gguf-parser-go v0.13.19
+	github.com/sirupsen/logrus v1.9.3
 	github.com/testcontainers/testcontainers-go/modules/registry v0.35.0
 )
 
@@ -33,7 +35,6 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/gpustack/gguf-parser-go v0.13.19 // indirect
 	github.com/henvic/httpretty v0.1.4 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
@@ -57,7 +58,6 @@ require (
 	github.com/rs/dnscache v0.0.0-20230804202142-fc85eb664529 // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smallnest/ringbuffer v0.0.0-20241116012123-461381446e3d // indirect
 	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/testcontainers/testcontainers-go v0.35.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
-golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
+golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
+golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/gguf/create.go
+++ b/pkg/gguf/create.go
@@ -3,6 +3,7 @@ package gguf
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	gguf_parser "github.com/gpustack/gguf-parser-go"
@@ -20,9 +21,13 @@ func NewModel(path string) (*Model, error) {
 		return nil, fmt.Errorf("get gguf layer diffID: %w", err)
 	}
 
+	created := time.Now()
 	return &Model{
 		configFile: types.ConfigFile{
 			Config: configFromFile(path),
+			Descriptor: types.Descriptor{
+				Created: &created,
+			},
 			RootFS: v1.RootFS{
 				Type: "rootfs",
 				DiffIDs: []v1.Hash{

--- a/pkg/gguf/model.go
+++ b/pkg/gguf/model.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	ggcr "github.com/google/go-containerregistry/pkg/v1/types"
 
+	mdpartial "github.com/docker/model-distribution/pkg/partial"
 	"github.com/docker/model-distribution/pkg/types"
 )
 
@@ -32,7 +33,7 @@ func (m *Model) ConfigName() (v1.Hash, error) {
 }
 
 func (m *Model) ConfigFile() (*v1.ConfigFile, error) {
-	panic("implement me")
+	return nil, fmt.Errorf("invalid for model")
 }
 
 func (m *Model) Digest() (v1.Hash, error) {
@@ -73,11 +74,29 @@ func (m *Model) Manifest() (*v1.Manifest, error) {
 }
 
 func (m *Model) LayerByDigest(hash v1.Hash) (v1.Layer, error) {
-	panic("implement me")
+	for _, l := range m.layers {
+		d, err := l.Digest()
+		if err != nil {
+			return nil, fmt.Errorf("get layer digest: %w", err)
+		}
+		if d == hash {
+			return l, nil
+		}
+	}
+	return nil, fmt.Errorf("layer not found")
 }
 
 func (m *Model) LayerByDiffID(hash v1.Hash) (v1.Layer, error) {
-	panic("implement me")
+	for _, l := range m.layers {
+		d, err := l.DiffID()
+		if err != nil {
+			return nil, fmt.Errorf("get layer digest: %w", err)
+		}
+		if d == hash {
+			return l, nil
+		}
+	}
+	return nil, fmt.Errorf("layer not found")
 }
 
 func (m *Model) RawManifest() ([]byte, error) {
@@ -96,14 +115,14 @@ func (m *Model) MediaType() (ggcr.MediaType, error) {
 	return manifest.MediaType, nil
 }
 
-func (m *Model) Config() (types.Config, error) {
-	return m.configFile.Config, nil
+func (m *Model) ID() (string, error) {
+	return mdpartial.ID(m)
 }
 
-func (m *Model) ID() (string, error) {
-	dgst, err := m.Digest()
-	if err != nil {
-		return "", fmt.Errorf("get digest: %w", err)
-	}
-	return dgst.String(), err
+func (m *Model) Config() (types.Config, error) {
+	return mdpartial.Config(m)
+}
+
+func (m *Model) Descriptor() (types.Descriptor, error) {
+	return mdpartial.Descriptor(m)
 }

--- a/pkg/gguf/model_test.go
+++ b/pkg/gguf/model_test.go
@@ -36,5 +36,15 @@ func TestGGUF(t *testing.T) {
 				t.Fatalf("Unexpected quantization: got %s expected %s", cfg.Quantization, "Unknown")
 			}
 		})
+
+		t.Run("TestDescriptor", func(t *testing.T) {
+			desc, err := mdl.Descriptor()
+			if err != nil {
+				t.Fatalf("Failed to get config: %v", err)
+			}
+			if desc.Created == nil {
+				t.Fatal("Expected created time to be set: got ni")
+			}
+		})
 	})
 }

--- a/pkg/partial/partial.go
+++ b/pkg/partial/partial.go
@@ -1,0 +1,59 @@
+package partial
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+
+	"github.com/docker/model-distribution/pkg/types"
+)
+
+type WithRawConfigFile interface {
+	// RawConfigFile returns the serialized bytes of this model's config file.
+	RawConfigFile() ([]byte, error)
+}
+
+func ConfigFile(i WithRawConfigFile) (*types.ConfigFile, error) {
+	raw, err := i.RawConfigFile()
+	if err != nil {
+		return nil, fmt.Errorf("get raw config file: %w", err)
+	}
+	var cf types.ConfigFile
+	if err := json.Unmarshal(raw, &cf); err != nil {
+		return nil, fmt.Errorf("unmarshal : %w", err)
+	}
+	return &cf, nil
+}
+
+// Config returns the types.Config for the model.
+func Config(i WithRawConfigFile) (types.Config, error) {
+	cf, err := ConfigFile(i)
+	if err != nil {
+		return types.Config{}, fmt.Errorf("config file: %w", err)
+	}
+	return cf.Config, nil
+}
+
+// Descriptor returns the types.Descriptor for the model.
+func Descriptor(i WithRawConfigFile) (types.Descriptor, error) {
+	cf, err := ConfigFile(i)
+	if err != nil {
+		return types.Descriptor{}, fmt.Errorf("config file: %w", err)
+	}
+	return cf.Descriptor, nil
+}
+
+// WithRawManifest defines the subset of types.Model used by these helper methods
+type WithRawManifest interface {
+	// RawManifest returns the serialized bytes of this model's manifest file.
+	RawManifest() ([]byte, error)
+}
+
+func ID(i WithRawManifest) (string, error) {
+	digest, err := partial.Digest(i)
+	if err != nil {
+		return "", fmt.Errorf("get digest: %w", err)
+	}
+	return digest.String(), nil
+}

--- a/pkg/store/model.go
+++ b/pkg/store/model.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -12,18 +11,19 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 
 	"github.com/docker/model-distribution/pkg/gguf"
+	mdpartial "github.com/docker/model-distribution/pkg/partial"
 	mdtypes "github.com/docker/model-distribution/pkg/types"
 )
 
 var _ v1.Image = &Model{}
 
 type Model struct {
-	rawManfiest []byte
+	rawManifest []byte
 	blobsDir    string
 	tags        []string
 }
 
-func (m Model) Layers() ([]v1.Layer, error) {
+func (m *Model) Layers() ([]v1.Layer, error) {
 	manifest, err := m.Manifest()
 	if err != nil {
 		return nil, fmt.Errorf("get manifest: %w", err)
@@ -38,7 +38,7 @@ func (m Model) Layers() ([]v1.Layer, error) {
 	return layers, nil
 }
 
-func (m Model) MediaType() (types.MediaType, error) {
+func (m *Model) MediaType() (types.MediaType, error) {
 	manifest, err := m.Manifest()
 	if err != nil {
 		return "", fmt.Errorf("get manifest: %w", err)
@@ -46,19 +46,19 @@ func (m Model) MediaType() (types.MediaType, error) {
 	return manifest.MediaType, nil
 }
 
-func (m Model) Size() (int64, error) {
+func (m *Model) Size() (int64, error) {
 	return partial.Size(m)
 }
 
-func (m Model) ConfigName() (v1.Hash, error) {
+func (m *Model) ConfigName() (v1.Hash, error) {
 	return partial.ConfigName(m)
 }
 
-func (m Model) ConfigFile() (*v1.ConfigFile, error) {
+func (m *Model) ConfigFile() (*v1.ConfigFile, error) {
 	return nil, errors.New("invalid for model")
 }
 
-func (m Model) RawConfigFile() ([]byte, error) {
+func (m *Model) RawConfigFile() ([]byte, error) {
 	manifest, err := m.Manifest()
 	if err != nil {
 		return nil, fmt.Errorf("get manifest: %w", err)
@@ -71,19 +71,19 @@ func (m Model) RawConfigFile() ([]byte, error) {
 	return rawConfig, nil
 }
 
-func (m Model) Digest() (v1.Hash, error) {
+func (m *Model) Digest() (v1.Hash, error) {
 	return partial.Digest(m)
 }
 
-func (m Model) Manifest() (*v1.Manifest, error) {
+func (m *Model) Manifest() (*v1.Manifest, error) {
 	return partial.Manifest(m)
 }
 
-func (m Model) RawManifest() ([]byte, error) {
-	return m.rawManfiest, nil
+func (m *Model) RawManifest() ([]byte, error) {
+	return m.rawManifest, nil
 }
 
-func (m Model) LayerByDigest(hash v1.Hash) (v1.Layer, error) {
+func (m *Model) LayerByDigest(hash v1.Hash) (v1.Layer, error) {
 	layers, err := m.Layers()
 	if err != nil {
 		return nil, err
@@ -100,11 +100,11 @@ func (m Model) LayerByDigest(hash v1.Hash) (v1.Layer, error) {
 	return nil, fmt.Errorf("layer with digest %s not found", hash)
 }
 
-func (m Model) LayerByDiffID(hash v1.Hash) (v1.Layer, error) {
+func (m *Model) LayerByDiffID(hash v1.Hash) (v1.Layer, error) {
 	return m.LayerByDigest(hash)
 }
 
-func (m Model) GGUFPath() (string, error) {
+func (m *Model) GGUFPath() (string, error) {
 	manifest, err := m.Manifest()
 	if err != nil {
 		return "", fmt.Errorf("get manifest: %w", err)
@@ -117,26 +117,18 @@ func (m Model) GGUFPath() (string, error) {
 	return "", errors.New("missing GGUF layer in manifest")
 }
 
-func (m Model) Tags() []string {
+func (m *Model) Tags() []string {
 	return m.tags
 }
 
-func (m Model) ID() (string, error) {
-	digest, err := m.Digest()
-	if err != nil {
-		return "", fmt.Errorf("get digest: %w", err)
-	}
-	return digest.String(), nil
+func (m *Model) ID() (string, error) {
+	return mdpartial.ID(m)
 }
 
-func (m Model) Config() (mdtypes.Config, error) {
-	raw, err := m.RawConfigFile()
-	if err != nil {
-		return mdtypes.Config{}, fmt.Errorf("get raw config file: %w", err)
-	}
-	var cf mdtypes.ConfigFile
-	if err := json.Unmarshal(raw, &cf); err != nil {
-		return mdtypes.Config{}, fmt.Errorf("unmarshal config: %w", err)
-	}
-	return cf.Config, nil
+func (m *Model) Config() (mdtypes.Config, error) {
+	return mdpartial.Config(m)
+}
+
+func (m *Model) Descriptor() (mdtypes.Descriptor, error) {
+	return mdpartial.Descriptor(m)
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -525,7 +525,7 @@ func (s *LocalStore) Read(tag string) (*Model, error) {
 					return nil, fmt.Errorf("reading manifest file: %w", err)
 				}
 				return &Model{
-					rawManfiest: rawManifest,
+					rawManifest: rawManifest,
 					blobsDir:    filepath.Join(s.rootPath, "blobs", "sha256"),
 					tags:        models.Models[i].Tags,
 				}, nil

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"time"
+
 	"github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
@@ -15,14 +17,21 @@ const (
 type Format string
 
 type ConfigFile struct {
-	Config Config    `json:"config"`
-	RootFS v1.RootFS `json:"rootfs"`
+	Config     Config     `json:"config"`
+	Descriptor Descriptor `json:"descriptor"`
+	RootFS     v1.RootFS  `json:"rootfs"`
 }
 
+// Config describes the model.
 type Config struct {
 	Format       Format `json:"format,omitempty"`
 	Quantization string `json:"quantization,omitempty"`
 	Parameters   string `json:"parameters,omitempty"`
 	Architecture string `json:"architecture,omitempty"`
 	Size         string `json:"size,omitempty"`
+}
+
+// Descriptor provides metadata about the provenance of the model.
+type Descriptor struct {
+	Created *time.Time `json:"created,omitempty"`
 }


### PR DESCRIPTION
This PR does the following:
* Adds a `descriptor` section with informational metadata to the config file. (things like `authors` or `description` could also go here).
* Adds `created` timestamp to the descriptor.
* When creating an artifact from a gguf file, set `created` to the current time.

Example config JSON:
```json
{
  "config": {
    "format": "gguf",
    "quantization": "Q4_0",
    "parameters": "1.10 B",
    "architecture": "llama",
    "size": "606.53 MiB"
  },
  "descriptor": {
    "created": "2025-03-14T17:47:50.136564-04:00"
  },
  "rootfs": {
    "type": "rootfs",
    "diff_ids": [
      "sha256:2af3b81862c6be03c769683af18efdadb2c33f60ff32ab6f83e42c043d6c7816"
    ]
  }
}
```