### PR TITLE
Avoid panic by waiting for progress updates goroutine to finish

### DIFF
--- a/pkg/distribution/client.go
+++ b/pkg/distribution/client.go
@@ -136,7 +136,6 @@ func (c *Client) PullModel(ctx context.Context, reference string, progressWriter
 	if progressWriter != nil {
 		// Create a buffered channel for progress updates
 		progress = make(chan v1.Update, 100)
-		defer close(progress)
 
 		// Start a goroutine to handle progress updates
 		// Wait for the goroutine to finish or `progressWriter`'s underlying Writer may be closed
@@ -167,7 +166,6 @@ func (c *Client) PullModel(ctx context.Context, reference string, progressWriter
 	remoteOpts := []remote.Option{
 		remote.WithAuthFromKeychain(authn.DefaultKeychain),
 		remote.WithContext(ctx),
-		remote.WithProgress(progress),
 	}
 
 	// Pull the image with progress tracking

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -261,6 +261,9 @@ func (s *LocalStore) Version() string {
 
 // Write writes a model to the store
 func (s *LocalStore) Write(mdl v1.Image, tags []string, progress chan<- v1.Update) error {
+	if progress != nil {
+		defer close(progress)
+	}
 	cf, err := mdl.RawConfigFile()
 	if err != nil {
 		return fmt.Errorf("get raw config file: %w", err)
@@ -294,7 +297,7 @@ func (s *LocalStore) Write(mdl v1.Image, tags []string, progress chan<- v1.Updat
 	}
 
 	// Gets SHA256 digest
-	//digest := manifest.Layers[0].Digest
+	// digest := manifest.Layers[0].Digest
 	sz, err := mdl.Size()
 	if err != nil {
 		return fmt.Errorf("getting model size: %w", err)


### PR DESCRIPTION
You can get a panic if the iteration through the progress updates finishes after PullModel returns and the progressWriter's underlying Writer is closed. You can simulate this by adding a time.Sleep(time.Second) between the updates and run a docker model pull - the pull will finish but the goroutine that handles progress updates will still be running and it will attempt to write to the progressWriter's underlying closed Writer.