### PR TITLE
Gets just the latest snapshot of the code

### DIFF
--- a/scripts/model-push/llama-converter/entrypoint.sh
+++ b/scripts/model-push/llama-converter/entrypoint.sh
@@ -55,7 +55,7 @@ if [[ "$FROM_HF" == "true" ]]; then
     else
         echo "Cloning Hugging Face repository: $HF_REPO into $TARGET_DIR..."
         git lfs install
-        git clone "https://user:$HUGGINGFACE_TOKEN@huggingface.co/$HF_REPO" "$TARGET_DIR"
+        git clone --depth=1 "https://user:$HUGGINGFACE_TOKEN@huggingface.co/$HF_REPO" "$TARGET_DIR"
     fi
 
     echo "Running conversion..."


### PR DESCRIPTION
Gets just the latest snapshot of the code to avoid getting the full history (no logs, no older commits).
To reduce the required disk space when pushing to Hub