### PR TITLE
store: Fix blob rename on windows

### DIFF
--- a/pkg/store/blobs.go
+++ b/pkg/store/blobs.go
@@ -58,6 +58,8 @@ func (s *LocalStore) writeBlob(layer blob, progress chan<- v1.Update) error {
 	if _, err := io.Copy(f, r); err != nil {
 		return fmt.Errorf("copy blob %q to store: %w", hash.String(), err)
 	}
+
+	f.Close() // Rename will fail on Windows if the file is still open.
 	if err := os.Rename(incompletePath(path), path); err != nil {
 		return fmt.Errorf("rename blob file: %w", err)
 	}


### PR DESCRIPTION
I ran into issues on windows where Rename on a blob would fail with:

The process cannot access the file because it is being used by another process.

So close the *.incomplete file before trying to rename it.