### PR TITLE
Add nil and empty string checks to With functions

### DIFF
--- a/pkg/distribution/client.go
+++ b/pkg/distribution/client.go
@@ -52,28 +52,36 @@ type options struct {
 // WithStoreRootPath sets the store root path
 func WithStoreRootPath(path string) Option {
 	return func(o *options) {
-		o.storeRootPath = path
+		if path != "" {
+			o.storeRootPath = path
+		}
 	}
 }
 
 // WithLogger sets the logger
 func WithLogger(logger *logrus.Entry) Option {
 	return func(o *options) {
-		o.logger = logger
+		if logger != nil {
+			o.logger = logger
+		}
 	}
 }
 
 // WithTransport sets the HTTP transport to use when pulling and pushing models.
 func WithTransport(transport http.RoundTripper) Option {
 	return func(o *options) {
-		o.transport = transport
+		if transport != nil {
+			o.transport = transport
+		}
 	}
 }
 
 // WithUserAgent sets the User-Agent header to use when pulling and pushing models.
 func WithUserAgent(ua string) Option {
 	return func(o *options) {
-		o.userAgent = ua
+		if ua != "" {
+			o.userAgent = ua
+		}
 	}
 }
 

--- a/pkg/distribution/client_test.go
+++ b/pkg/distribution/client_test.go
@@ -746,6 +746,92 @@ func TestClientDefaultLogger(t *testing.T) {
 	}
 }
 
+func TestWithFunctionsNilChecks(t *testing.T) {
+	// Create temp directory for store
+	tempDir, err := os.MkdirTemp("", "model-distribution-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Test WithStoreRootPath with empty string
+	t.Run("WithStoreRootPath empty string", func(t *testing.T) {
+		// Create options with a valid path first
+		opts := defaultOptions()
+		WithStoreRootPath(tempDir)(opts)
+
+		// Then try to override with empty string
+		WithStoreRootPath("")(opts)
+
+		// Verify the path wasn't changed to empty
+		if opts.storeRootPath != tempDir {
+			t.Errorf("WithStoreRootPath with empty string changed the path: got %q, want %q",
+				opts.storeRootPath, tempDir)
+		}
+	})
+
+	// Test WithLogger with nil
+	t.Run("WithLogger nil", func(t *testing.T) {
+		// Create options with default logger
+		opts := defaultOptions()
+		defaultLogger := opts.logger
+
+		// Try to override with nil
+		WithLogger(nil)(opts)
+
+		// Verify the logger wasn't changed to nil
+		if opts.logger == nil {
+			t.Error("WithLogger with nil changed logger to nil")
+		}
+
+		// Verify it's still the default logger
+		if opts.logger != defaultLogger {
+			t.Error("WithLogger with nil changed the logger")
+		}
+	})
+
+	// Test WithTransport with nil
+	t.Run("WithTransport nil", func(t *testing.T) {
+		// Create options with default transport
+		opts := defaultOptions()
+		defaultTransport := opts.transport
+
+		// Try to override with nil
+		WithTransport(nil)(opts)
+
+		// Verify the transport wasn't changed to nil
+		if opts.transport == nil {
+			t.Error("WithTransport with nil changed transport to nil")
+		}
+
+		// Verify it's still the default transport
+		if opts.transport != defaultTransport {
+			t.Error("WithTransport with nil changed the transport")
+		}
+	})
+
+	// Test WithUserAgent with empty string
+	t.Run("WithUserAgent empty string", func(t *testing.T) {
+		// Create options with default user agent
+		opts := defaultOptions()
+		defaultUA := opts.userAgent
+
+		// Try to override with empty string
+		WithUserAgent("")(opts)
+
+		// Verify the user agent wasn't changed to empty
+		if opts.userAgent == "" {
+			t.Error("WithUserAgent with empty string changed user agent to empty")
+		}
+
+		// Verify it's still the default user agent
+		if opts.userAgent != defaultUA {
+			t.Errorf("WithUserAgent with empty string changed the user agent: got %q, want %q",
+				opts.userAgent, defaultUA)
+		}
+	})
+}
+
 func TestNewReferenceError(t *testing.T) {
 	// Create temp directory for store
 	tempDir, err := os.MkdirTemp("", "model-distribution-test-*")


### PR DESCRIPTION
Add defensive checks to the functional options in client.go:
- Add nil checks to WithLogger and WithTransport
- Add empty string checks to WithStoreRootPath and WithUserAgent
- Add tests to verify these checks work correctly