### PR TITLE
docker model rm should behave like docker image rm when the model is not found

### DIFF
--- a/pkg/distribution/client_test.go
+++ b/pkg/distribution/client_test.go
@@ -711,6 +711,26 @@ func TestClientDeleteModel(t *testing.T) {
 	}
 }
 
+func TestClientDeleteNonexistentModel(t *testing.T) {
+	// Create temp directory for store
+	tempDir, err := os.MkdirTemp("", "model-distribution-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create client
+	client, err := NewClient(WithStoreRootPath(tempDir))
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Delete the model
+	if err := client.DeleteModel("some/missing:model"); !errors.Is(err, ErrModelNotFound) {
+		t.Fatalf("Should return ErrModelNotFound got: %v", err)
+	}
+}
+
 func TestClientDefaultLogger(t *testing.T) {
 	// Create temp directory for store
 	tempDir, err := os.MkdirTemp("", "model-distribution-test-*")

--- a/pkg/distribution/errors.go
+++ b/pkg/distribution/errors.go
@@ -3,13 +3,14 @@ package distribution
 import (
 	"errors"
 	"fmt"
+	"github.com/docker/model-distribution/pkg/store"
 
 	"github.com/docker/model-distribution/pkg/types"
 )
 
 var (
 	ErrInvalidReference     = errors.New("invalid model reference")
-	ErrModelNotFound        = errors.New("model not found")
+	ErrModelNotFound        = store.ErrModelNotFound
 	ErrUnauthorized         = errors.New("unauthorized access to model")
 	ErrUnsupportedMediaType = errors.New(fmt.Sprintf(
 		"client supports only models of type %q and older - try upgrading",

--- a/pkg/store/errors.go
+++ b/pkg/store/errors.go
@@ -1,0 +1,7 @@
+package store
+
+import (
+	"errors"
+)
+
+var ErrModelNotFound = errors.New("model not found")

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -75,7 +75,7 @@ func (s *LocalStore) List() ([]IndexEntry, error) {
 	return index.Models, nil
 }
 
-// Delete deletes a model by tag
+// Delete deletes a model by reference
 func (s *LocalStore) Delete(ref string) error {
 	idx, err := s.readIndex()
 	if err != nil {
@@ -83,8 +83,7 @@ func (s *LocalStore) Delete(ref string) error {
 	}
 	model, i, ok := idx.Find(ref)
 	if !ok {
-		// Model not found, nothing to delete
-		return nil
+		return ErrModelNotFound
 	}
 	idx = idx.UnTag(ref)
 

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -3,6 +3,7 @@ package store_test
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -175,6 +176,14 @@ func TestStoreAPI(t *testing.T) {
 		_, err = s.Read("api-model:latest")
 		if err == nil {
 			t.Errorf("Expected error after deletion, got nil")
+		}
+	})
+
+	// Test Delete Non Existent Model
+	t.Run("Delete", func(t *testing.T) {
+		err := s.Delete("non-existent-model:latest")
+		if !errors.Is(err, store.ErrModelNotFound) {
+			t.Fatalf("Expected ErrModelNotFound, got %v", err)
 		}
 	})
 


### PR DESCRIPTION
Difference between `docker model rm <ref>` and `docker image rm <ref>:`
```
docker model rm lala      
Failed to remove model: removing lala failed with status 404 Not Found: not found


25-03-21 14:21:02 ~/.docker/models % docker image rm lala      
Error response from daemon: No such image: lala:latest
25-03-21 14:21:05 ~/.docker/models % docker model rm lala/lalal
Model lala/lalal removed successfully
25-03-21 14:21:08 ~/.docker/models % docker image rm lala/lalal
Error response from daemon: No such image: lala/lalal:latest
```
This PR `adds store.ErrModelNotFound` to notify when a model is not been found to be removed, and uses it as alias of 
`distribution.ErrModelNotFound`. 
In `model-cli` we would be able to check if the error is `distribution.ErrModelNotFound` and if so return "No such model: <ref>"