### PR TITLE
Tag returns ErrModelNotFound when model is missing

### DIFF
--- a/internal/store/index.go
+++ b/internal/store/index.go
@@ -32,7 +32,7 @@ func (i Index) Tag(reference string, tag string) (Index, error) {
 		}
 	}
 	if !tagged {
-		return Index{}, fmt.Errorf("model not found")
+		return Index{}, ErrModelNotFound
 	}
 
 	return result, nil


### PR DESCRIPTION
Client returns `distribution.ErrNotFound` when `Tag` is called and source model is missing.