### PR TITLE
Push with progress

### DIFF
--- a/cmd/mdltool/main.go
+++ b/cmd/mdltool/main.go
@@ -230,7 +230,7 @@ func cmdPush(client *distribution.Client, args []string) int {
 	tag := args[0]
 	ctx := context.Background()
 
-	if err := client.PushModel(ctx, tag); err != nil {
+	if err := client.PushModel(ctx, tag, os.Stdout); err != nil {
 		fmt.Fprintf(os.Stderr, "Error pushing model: %v\n", err)
 		return 1
 	}

--- a/distribution/client.go
+++ b/distribution/client.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -133,7 +131,10 @@ func (c *Client) PullModel(ctx context.Context, reference string, progressWriter
 
 	// First, check the remote registry for the model's digest
 	c.log.Infoln("Checking remote registry for model:", reference)
-	opts := append([]remote.Option{remote.WithContext(ctx)}, c.remoteOptions...)
+	opts := append([]remote.Option{
+		remote.WithContext(ctx),
+		remote.WithProgress(nil),
+	}, c.remoteOptions...)
 	remoteImg, err := remote.Image(ref, opts...)
 	if err != nil {
 		errStr := err.Error()
@@ -198,40 +199,14 @@ func (c *Client) PullModel(ctx context.Context, reference string, progressWriter
 
 	// Model doesn't exist in local store or digests don't match, pull from remote
 
-	var wg sync.WaitGroup
-	var progress chan v1.Update
-	// Start a goroutine to handle progress updates
-	// Wait for the goroutine to finish or `progressWriter`'s underlying Writer may be closed
-	wg.Add(1)
-	defer wg.Wait()
-
-	// Create a buffered channel for progress updates
-	progress = make(chan v1.Update, 100)
-	defer close(progress)
-	go func() {
-		defer wg.Done()
-		var lastComplete int64
-		var lastUpdate time.Time
-		const updateInterval = 500 * time.Millisecond // Update every 500ms
-		const minBytesForUpdate = 1024 * 1024         // At least 1MB difference
-
-		for p := range progress {
-			now := time.Now()
-			bytesDownloaded := p.Complete - lastComplete
-			// Only update if enough time has passed or enough bytes downloaded
-			if now.Sub(lastUpdate) >= updateInterval || bytesDownloaded >= minBytesForUpdate {
-				if err := writeProgress(progressWriter, p.Complete); err != nil {
-					c.log.Warnf("Failed to write progress: %v", err)
-					// If we fail to write progress, don't try again
-					progressWriter = nil
-				}
-				lastUpdate = now
-				lastComplete = p.Complete
-			}
+	pr := newProgressReporter(progressWriter, pullMsg)
+	defer func() {
+		if err := pr.Wait(); err != nil {
+			c.log.Warnf("Failed to write progress: %v", err)
 		}
 	}()
 
-	if err = c.store.Write(remoteImg, []string{reference}, progress); err != nil {
+	if err = c.store.Write(remoteImg, []string{reference}, pr.updates()); err != nil {
 		if writeErr := writeError(progressWriter, fmt.Sprintf("Error: %s", err.Error())); writeErr != nil {
 			c.log.Warnf("Failed to write error message: %v", writeErr)
 			// If we fail to write error message, don't try again
@@ -303,7 +278,7 @@ func (c *Client) Tag(source string, target string) error {
 }
 
 // PushModel pushes a tagged model from the content store to the registry.
-func (c *Client) PushModel(ctx context.Context, tag string) (err error) {
+func (c *Client) PushModel(ctx context.Context, tag string, progressWriter io.Writer) (err error) {
 	// Parse the tag
 	ref, err := name.NewTag(tag)
 	if err != nil {
@@ -318,15 +293,32 @@ func (c *Client) PushModel(ctx context.Context, tag string) (err error) {
 
 	// Push the model
 	c.log.Infoln("Pushing model:", tag)
-	// todo: report progress
 
-	opts := append([]remote.Option{remote.WithContext(ctx)}, c.remoteOptions...)
+	pr := newProgressReporter(progressWriter, pushMsg)
+	defer func() {
+		if err := pr.Wait(); err != nil {
+			c.log.Warnf("Failed to write progress: %v", err)
+		}
+	}()
+
+	opts := append([]remote.Option{
+		remote.WithContext(ctx),
+		remote.WithProgress(pr.updates()),
+	}, c.remoteOptions...)
+
 	if err := remote.Write(ref, mdl, opts...); err != nil {
 		c.log.Errorln("Failed to push image:", err, "reference:", tag)
+		if writeErr := writeError(progressWriter, fmt.Sprintf("Error: %s", err.Error())); writeErr != nil {
+			c.log.Warnf("Failed to write error message: %v", writeErr)
+		}
 		return fmt.Errorf("pushing image: %w", err)
 	}
 
 	c.log.Infoln("Successfully pushed model:", tag)
+	if err := writeSuccess(progressWriter, "Model pushed successfully"); err != nil {
+		c.log.Warnf("Failed to write success message: %v", err)
+	}
+
 	return nil
 }
 

--- a/distribution/client.go
+++ b/distribution/client.go
@@ -131,10 +131,7 @@ func (c *Client) PullModel(ctx context.Context, reference string, progressWriter
 
 	// First, check the remote registry for the model's digest
 	c.log.Infoln("Checking remote registry for model:", reference)
-	opts := append([]remote.Option{
-		remote.WithContext(ctx),
-		remote.WithProgress(nil),
-	}, c.remoteOptions...)
+	opts := append([]remote.Option{remote.WithContext(ctx)}, c.remoteOptions...)
 	remoteImg, err := remote.Image(ref, opts...)
 	if err != nil {
 		errStr := err.Error()

--- a/distribution/ecr_test.go
+++ b/distribution/ecr_test.go
@@ -48,7 +48,7 @@ func TestECRIntegration(t *testing.T) {
 		if err := client.store.Write(mdl, []string{ecrTag}, nil); err != nil {
 			t.Fatalf("Failed to write model to store: %v", err)
 		}
-		if err := client.PushModel(context.Background(), ecrTag); err != nil {
+		if err := client.PushModel(context.Background(), ecrTag, nil); err != nil {
 			t.Fatalf("Failed to push model to ECR: %v", err)
 		}
 		if err := client.DeleteModel(ecrTag); err != nil { // cleanup

--- a/distribution/gar_test.go
+++ b/distribution/gar_test.go
@@ -49,7 +49,7 @@ func TestGARIntegration(t *testing.T) {
 		if err := client.store.Write(mdl, []string{garTag}, nil); err != nil {
 			t.Fatalf("Failed to write model to store: %v", err)
 		}
-		if err := client.PushModel(context.Background(), garTag); err != nil {
+		if err := client.PushModel(context.Background(), garTag, nil); err != nil {
 			t.Fatalf("Failed to push model to ECR: %v", err)
 		}
 		if err := client.DeleteModel(garTag); err != nil { // cleanup

--- a/distribution/progress.go
+++ b/distribution/progress.go
@@ -4,12 +4,78 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"time"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 // ProgressMessage represents a structured message for progress reporting
 type ProgressMessage struct {
 	Type    string `json:"type"`    // "progress", "success", or "error"
 	Message string `json:"message"` // Human-readable message
+}
+
+type reporter struct {
+	progress chan v1.Update
+	done     chan struct{}
+	err      error
+	out      io.Writer
+	format   progressF
+}
+
+type progressF func(update v1.Update) string
+
+func pullMsg(update v1.Update) string {
+	return fmt.Sprintf("Downloaded: %.2f MB", float64(update.Complete)/1024/1024)
+}
+
+func pushMsg(update v1.Update) string {
+	return fmt.Sprintf("Uploaded: %.2f MB", float64(update.Complete)/1024/1024)
+}
+
+func newProgressReporter(w io.Writer, msgF progressF) *reporter {
+	return &reporter{
+		out:      w,
+		progress: make(chan v1.Update, 100),
+		done:     make(chan struct{}),
+		format:   msgF,
+	}
+}
+
+// updates returns a channel for receiving progress updates. It is the responsibility of the caller to close
+// the channel when they are done sending updates. Should only be called once per reporter instance.
+func (r *reporter) updates() chan<- v1.Update {
+	go func() {
+		var lastComplete int64
+		var lastUpdate time.Time
+		const updateInterval = 500 * time.Millisecond // Update every 500ms
+		const minBytesForUpdate = 1024 * 1024         // At least 1MB difference
+
+		for p := range r.progress {
+			if r.err != nil {
+				continue // If we fail to write progress, don't try again
+			}
+			now := time.Now()
+			bytesDownloaded := p.Complete - lastComplete
+			// Only update if enough time has passed or enough bytes downloaded or finished
+			if now.Sub(lastUpdate) >= updateInterval ||
+				bytesDownloaded >= minBytesForUpdate {
+				if err := writeProgress(r.out, r.format(p)); err != nil {
+					r.err = err
+				}
+				lastUpdate = now
+				lastComplete = p.Complete
+			}
+		}
+		close(r.done) // Close the done channel when progress is complete
+	}()
+	return r.progress
+}
+
+// Wait waits for the progress reporter to finish and returns any error encountered.
+func (r *reporter) Wait() error {
+	<-r.done
+	return r.err
 }
 
 // writeProgressMessage writes a JSON-formatted progress message to the writer
@@ -26,13 +92,10 @@ func writeProgressMessage(w io.Writer, msg ProgressMessage) error {
 }
 
 // writeProgress writes a progress update message
-func writeProgress(w io.Writer, complete int64) error {
-	if complete == 0 {
-		return nil
-	}
+func writeProgress(w io.Writer, msg string) error {
 	return writeProgressMessage(w, ProgressMessage{
 		Type:    "progress",
-		Message: fmt.Sprintf("Downloaded: %.2f MB", float64(complete)/1024/1024),
+		Message: msg,
 	})
 }
 

--- a/distribution/progress.go
+++ b/distribution/progress.go
@@ -36,7 +36,7 @@ func pushMsg(update v1.Update) string {
 func newProgressReporter(w io.Writer, msgF progressF) *reporter {
 	return &reporter{
 		out:      w,
-		progress: make(chan v1.Update, 100),
+		progress: make(chan v1.Update),
 		done:     make(chan struct{}),
 		format:   msgF,
 	}
@@ -52,7 +52,7 @@ func (r *reporter) updates() chan<- v1.Update {
 		const minBytesForUpdate = 1024 * 1024         // At least 1MB difference
 
 		for p := range r.progress {
-			if r.err != nil {
+			if r.out == nil || r.err != nil {
 				continue // If we fail to write progress, don't try again
 			}
 			now := time.Now()

--- a/distribution/progress_test.go
+++ b/distribution/progress_test.go
@@ -4,12 +4,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 func TestProgressMessages(t *testing.T) {
 	t.Run("writeProgress", func(t *testing.T) {
 		var buf bytes.Buffer
-		err := writeProgress(&buf, 1024*1024)
+		err := writeProgress(&buf, pullMsg(v1.Update{
+			Complete: 1024 * 1024,
+		}))
 		if err != nil {
 			t.Fatalf("Failed to write progress message: %v", err)
 		}

--- a/internal/store/model.go
+++ b/internal/store/model.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -41,21 +40,11 @@ func (s *LocalStore) newModel(digest v1.Hash, tags []string) (*Model, error) {
 		return nil, fmt.Errorf("read config file: %w", err)
 	}
 
-	var cf mdtypes.ConfigFile
-	if err := json.Unmarshal(rawConfigFile, &cf); err != nil {
-		return nil, fmt.Errorf("unmarshal : %w", err)
-	}
-	//
-	//cfg, err := mdpartial.Config(rawConfigFile)
-	//if err != nil {
-	//	return nil, fmt.Errorf("parse config file: %w", err)
-	//}
-
 	layers := make([]v1.Layer, len(manifest.Layers))
-	for i, diffID := range cf.RootFS.DiffIDs {
+	for i, ld := range manifest.Layers {
 		layers[i] = &mdpartial.Layer{
-			Path:       s.blobPath(diffID),
-			Descriptor: manifest.Layers[i],
+			Path:       s.blobPath(ld.Digest),
+			Descriptor: ld,
 		}
 	}
 

--- a/internal/store/model.go
+++ b/internal/store/model.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -40,11 +41,21 @@ func (s *LocalStore) newModel(digest v1.Hash, tags []string) (*Model, error) {
 		return nil, fmt.Errorf("read config file: %w", err)
 	}
 
+	var cf mdtypes.ConfigFile
+	if err := json.Unmarshal(rawConfigFile, &cf); err != nil {
+		return nil, fmt.Errorf("unmarshal : %w", err)
+	}
+	//
+	//cfg, err := mdpartial.Config(rawConfigFile)
+	//if err != nil {
+	//	return nil, fmt.Errorf("parse config file: %w", err)
+	//}
+
 	layers := make([]v1.Layer, len(manifest.Layers))
-	for i, ld := range manifest.Layers {
+	for i, diffID := range cf.RootFS.DiffIDs {
 		layers[i] = &mdpartial.Layer{
-			Path:       s.blobPath(ld.Digest),
-			Descriptor: ld,
+			Path:       s.blobPath(diffID),
+			Descriptor: manifest.Layers[i],
 		}
 	}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -170,6 +170,10 @@ func (s *LocalStore) Version() string {
 
 // Write writes a model to the store
 func (s *LocalStore) Write(mdl v1.Image, tags []string, progress chan<- v1.Update) error {
+	if progress != nil {
+		defer close(progress)
+	}
+
 	// Write the config JSON file
 	if err := s.writeConfigFile(mdl); err != nil {
 		return fmt.Errorf("writing config file: %w", err)


### PR DESCRIPTION
* `PushModel` accepts a `progressWriter` and writes JSON progress updates.
* Some refactoring of the progress reporting code (could still use further improvement).
* Removes buffering from updates channel to ensure success/error message follows progress updates.
* Requires the code that writes to the updates channel to close the channel when finished writing in order to:
  * clearly indicate when updates are complete
  * make `store.Write` behavior consistent with `remote.Write`