### PR TITLE
Force delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ make build
 # Get the local file path for a model
 ./bin/model-distribution-tool get-path registry.example.com/models/llama:v1.0
 
-# Remove a model from the local store
+# Remove a model from the local store (will untag w/o deleting if there are multiple tags)
 ./bin/model-distribution-tool rm registry.example.com/models/llama:v1.0
+
+# Force Removal of a model from the local store, even when there are multiple referring tags
+./bin/model-distribution-tool rm --force sha256:0b329b335467cccf7aa219e8f5e1bd65e59b6dfa81cfa42fba2f8881268fbf82
 
 # Tag a model with an additional reference
 ./bin/model-distribution-tool tag registry.example.com/models/llama:v1.0 registry.example.com/models/llama:latest
@@ -97,7 +100,7 @@ if err != nil {
 }
 
 // Delete a model
-err = client.DeleteModel("registry.example.com/models/llama:v1.0")
+err = client.DeleteModel("registry.example.com/models/llama:v1.0", false)
 if err != nil {
     // Handle error
 }

--- a/cmd/mdltool/main.go
+++ b/cmd/mdltool/main.go
@@ -346,7 +346,7 @@ func cmdRm(client *distribution.Client, args []string) int {
 
 	reference := args[0]
 
-	if err := client.DeleteModel(reference); err != nil {
+	if err := client.DeleteModel(reference, false); err != nil {
 		fmt.Fprintf(os.Stderr, "Error removing model: %v\n", err)
 		return 1
 	}

--- a/cmd/mdltool/main.go
+++ b/cmd/mdltool/main.go
@@ -338,15 +338,25 @@ func cmdGetPath(client *distribution.Client, args []string) int {
 }
 
 func cmdRm(client *distribution.Client, args []string) int {
+	var force bool
+	fs := flag.NewFlagSet("rm", flag.ExitOnError)
+	fs.BoolVar(&force, "force", false, "Force remove the model")
+
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing flags: %v\n", err)
+		return 1
+	}
+	args = fs.Args()
+
 	if len(args) < 1 {
 		fmt.Fprintf(os.Stderr, "Error: missing reference argument\n")
-		fmt.Fprintf(os.Stderr, "Usage: model-distribution-tool rm <reference>\n")
+		fmt.Fprintf(os.Stderr, "Usage: model-distribution-tool rm [--force] <reference>\n")
 		return 1
 	}
 
 	reference := args[0]
 
-	if err := client.DeleteModel(reference, false); err != nil {
+	if err := client.DeleteModel(reference, force); err != nil {
 		fmt.Fprintf(os.Stderr, "Error removing model: %v\n", err)
 		return 1
 	}

--- a/distribution/client_test.go
+++ b/distribution/client_test.go
@@ -244,7 +244,7 @@ func TestClientPullModel(t *testing.T) {
 		}
 
 		// Delete the local model to force a pull
-		if err := client.DeleteModel(tag); err != nil {
+		if err := client.DeleteModel(tag, false); err != nil {
 			t.Fatalf("Failed to delete model: %v", err)
 		}
 
@@ -673,64 +673,6 @@ func TestClientGetStorePath(t *testing.T) {
 	}
 }
 
-func TestClientDeleteModel(t *testing.T) {
-	// Create temp directory for store
-	tempDir, err := os.MkdirTemp("", "model-distribution-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	// Create client
-	client, err := NewClient(WithStoreRootPath(tempDir))
-	if err != nil {
-		t.Fatalf("Failed to create client: %v", err)
-	}
-
-	// Use the dummy.gguf file from assets directory
-	mdl, err := gguf.NewModel(testGGUFFile)
-	if err != nil {
-		t.Fatalf("Failed to create model: %v", err)
-	}
-
-	// Push model to local store
-	tag := "test/model:v1.0.0"
-	if err := client.store.Write(mdl, []string{tag}, nil); err != nil {
-		t.Fatalf("Failed to push model to store: %v", err)
-	}
-
-	// Delete the model
-	if err := client.DeleteModel(tag); err != nil {
-		t.Fatalf("Failed to delete model: %v", err)
-	}
-
-	// Verify model is deleted
-	_, err = client.GetModel(tag)
-	if !errors.Is(err, ErrModelNotFound) {
-		t.Errorf("Expected ErrModelNotFound after deletion, got %v", err)
-	}
-}
-
-func TestClientDeleteNonexistentModel(t *testing.T) {
-	// Create temp directory for store
-	tempDir, err := os.MkdirTemp("", "model-distribution-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	// Create client
-	client, err := NewClient(WithStoreRootPath(tempDir))
-	if err != nil {
-		t.Fatalf("Failed to create client: %v", err)
-	}
-
-	// Delete the model
-	if err := client.DeleteModel("some/missing:model"); !errors.Is(err, ErrModelNotFound) {
-		t.Fatalf("Should return ErrModelNotFound got: %v", err)
-	}
-}
-
 func TestClientDefaultLogger(t *testing.T) {
 	// Create temp directory for store
 	tempDir, err := os.MkdirTemp("", "model-distribution-test-*")
@@ -933,7 +875,7 @@ func TestPush(t *testing.T) {
 	}
 
 	// Delete local copy (so we can test pulling)
-	if err := client.DeleteModel(tag); err != nil {
+	if err := client.DeleteModel(tag, false); err != nil {
 		t.Fatalf("Failed to delete model: %v", err)
 	}
 

--- a/distribution/delete_test.go
+++ b/distribution/delete_test.go
@@ -1,0 +1,146 @@
+package distribution
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/docker/model-distribution/internal/gguf"
+)
+
+func TestDeleteModel(t *testing.T) {
+	// Create temp directory for store
+	tempDir, err := os.MkdirTemp("", "model-distribution-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create client
+	client, err := NewClient(WithStoreRootPath(tempDir))
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Use the dummy.gguf file from assets directory
+	mdl, err := gguf.NewModel(testGGUFFile)
+	if err != nil {
+		t.Fatalf("Failed to create model: %v", err)
+	}
+	id, err := mdl.ID()
+	if err != nil {
+		t.Fatalf("Failed to get model ID: %v", err)
+	}
+	if err := client.store.Write(mdl, []string{}, nil); err != nil {
+		t.Fatalf("Failed to write model to store: %v", err)
+	}
+
+	type testCase struct {
+		ref         string   // ref to delete by (id or tag)
+		tags        []string // applied tags
+		force       bool
+		expectedErr error
+		description string
+		untagOnly   bool
+	}
+
+	tcs := []testCase{
+		{
+			ref:         id,
+			description: "untagged, by ID",
+		},
+		{
+			ref:         id,
+			force:       true,
+			description: "untagged, by ID, with force",
+		},
+		{
+			ref:         id,
+			tags:        []string{"some-repo:some-tag"},
+			description: "one tag, by ID",
+		},
+		{
+			ref:         "some-repo:some-tag",
+			tags:        []string{"some-repo:some-tag"},
+			description: "one tag, by tag",
+		},
+		{
+			ref:         id,
+			tags:        []string{"some-repo:some-tag"},
+			force:       true,
+			description: "one tag, by ID, with force",
+		},
+		{
+			ref:         "some-repo:some-tag",
+			tags:        []string{"some-repo:some-tag"},
+			force:       true,
+			description: "one tag, by tag, with force",
+		},
+		{
+			ref:         id,
+			tags:        []string{"some-repo:some-tag", "other-repo:other-tag"},
+			expectedErr: ErrConflict,
+			description: "multiple tags, by ID",
+		},
+		{
+			ref:         id,
+			tags:        []string{"some-repo:some-tag", "other-repo:other-tag"},
+			force:       true,
+			description: "multiple tags, by ID, with force",
+		},
+		{
+			ref:         "some-repo:some-tag",
+			tags:        []string{"some-repo:some-tag", "other-repo:other-tag"},
+			untagOnly:   true,
+			description: "multiple tags, by tag",
+		},
+		{
+			ref:         "some-repo:some-tag",
+			tags:        []string{"some-repo:some-tag", "other-repo:other-tag"},
+			force:       true,
+			untagOnly:   true,
+			description: "multiple tags, by tag, with force",
+		},
+		{
+			ref:         "not-existing:tag",
+			tags:        []string{},
+			expectedErr: ErrModelNotFound,
+			description: "no such model",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.description, func(t *testing.T) {
+			// Setup model with tags
+			if err := client.store.Write(mdl, []string{}, nil); err != nil {
+				t.Fatalf("Failed to write model to store: %v", err)
+			}
+			for _, tag := range tc.tags {
+				if err := client.Tag(id, tag); err != nil {
+					t.Fatalf("Failed to tag model: %v", err)
+				}
+			}
+
+			// Attempt to delete the model and check for expected error
+			if err := client.DeleteModel(tc.ref, tc.force); !errors.Is(err, tc.expectedErr) {
+				t.Fatalf("Expected error %v, got: %v", tc.expectedErr, err)
+			}
+			if tc.expectedErr != nil {
+				return
+			}
+
+			// Verify model ref unreachable by ref (untagged)
+			_, err = client.GetModel(tc.ref)
+			if !errors.Is(err, ErrModelNotFound) {
+				t.Errorf("Expected ErrModelNotFound after deletion, got %v", err)
+			}
+
+			// Verify if underlying model is deleted
+			if _, err = client.GetModel(id); !tc.untagOnly && !errors.Is(err, ErrModelNotFound) {
+				t.Errorf("Expected ErrModelNotFound after deletion, got %v", err)
+			} else if tc.untagOnly && err != nil {
+				t.Errorf("Expected model to remain but was deleted")
+			}
+		})
+	}
+}

--- a/distribution/ecr_test.go
+++ b/distribution/ecr_test.go
@@ -51,7 +51,7 @@ func TestECRIntegration(t *testing.T) {
 		if err := client.PushModel(context.Background(), ecrTag, nil); err != nil {
 			t.Fatalf("Failed to push model to ECR: %v", err)
 		}
-		if err := client.DeleteModel(ecrTag); err != nil { // cleanup
+		if err := client.DeleteModel(ecrTag, false); err != nil { // cleanup
 			t.Fatalf("Failed to delete model from store: %v", err)
 		}
 	})

--- a/distribution/errors.go
+++ b/distribution/errors.go
@@ -16,6 +16,7 @@ var (
 		"client supports only models of type %q and older - try upgrading",
 		types.MediaTypeModelConfigV01,
 	))
+	ErrConflict = errors.New("resource conflict")
 )
 
 // ReferenceError represents an error related to an invalid model reference

--- a/distribution/gar_test.go
+++ b/distribution/gar_test.go
@@ -52,7 +52,7 @@ func TestGARIntegration(t *testing.T) {
 		if err := client.PushModel(context.Background(), garTag, nil); err != nil {
 			t.Fatalf("Failed to push model to ECR: %v", err)
 		}
-		if err := client.DeleteModel(garTag); err != nil { // cleanup
+		if err := client.DeleteModel(garTag, false); err != nil { // cleanup
 			t.Fatalf("Failed to delete model from store: %v", err)
 		}
 	})

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -81,51 +81,47 @@ func (s *LocalStore) Delete(ref string) error {
 	if err != nil {
 		return fmt.Errorf("reading models file: %w", err)
 	}
-	model, i, ok := idx.Find(ref)
+	model, _, ok := idx.Find(ref)
 	if !ok {
 		return ErrModelNotFound
 	}
-	idx = idx.UnTag(ref)
 
-	// If no more tags, remove the model and check if its blobs can be deleted
-	if len(idx.Models[i].Tags) == 0 {
-		// Remove manifest file
-		if digest, err := v1.NewHash(model.ID); err != nil {
-			fmt.Printf("Warning: failed to parse manifest digest %s: %v\n", digest, err)
-		} else if err := s.removeManifest(digest); err != nil {
-			fmt.Printf("Warning: failed to remove manifest %q: %v\n",
-				digest, err,
-			)
-		}
-		// Before deleting blobs, check if they are referenced by other models
-		blobRefs := make(map[string]int)
-		for _, m := range idx.Models {
-			if m.ID == model.ID {
-				continue // Skip the model being deleted
-			}
-			for _, file := range m.Files {
-				blobRefs[file]++
-			}
-		}
-		// Only delete blobs that are not referenced by other models
-		for _, blobFile := range model.Files {
-			if blobRefs[blobFile] > 0 {
-				// Skip deletion if blob is referenced by other models
-				continue
-			}
-			hash, err := v1.NewHash(blobFile)
-			if err != nil {
-				fmt.Printf("Warning: failed to parse blob hash %s: %v\n", blobFile, err)
-				continue
-			}
-			if err := s.removeBlob(hash); err != nil {
-				// Just log the error but don't fail the operation
-				fmt.Printf("Warning: failed to remove blob %q from store: %v\n", hash.String(), err)
-			}
-		}
-
-		idx = idx.Remove(model.ID)
+	// Remove manifest file
+	if digest, err := v1.NewHash(model.ID); err != nil {
+		fmt.Printf("Warning: failed to parse manifest digest %s: %v\n", digest, err)
+	} else if err := s.removeManifest(digest); err != nil {
+		fmt.Printf("Warning: failed to remove manifest %q: %v\n",
+			digest, err,
+		)
 	}
+	// Before deleting blobs, check if they are referenced by other models
+	blobRefs := make(map[string]int)
+	for _, m := range idx.Models {
+		if m.ID == model.ID {
+			continue // Skip the model being deleted
+		}
+		for _, file := range m.Files {
+			blobRefs[file]++
+		}
+	}
+	// Only delete blobs that are not referenced by other models
+	for _, blobFile := range model.Files {
+		if blobRefs[blobFile] > 0 {
+			// Skip deletion if blob is referenced by other models
+			continue
+		}
+		hash, err := v1.NewHash(blobFile)
+		if err != nil {
+			fmt.Printf("Warning: failed to parse blob hash %s: %v\n", blobFile, err)
+			continue
+		}
+		if err := s.removeBlob(hash); err != nil {
+			// Just log the error but don't fail the operation
+			fmt.Printf("Warning: failed to remove blob %q from store: %v\n", hash.String(), err)
+		}
+	}
+
+	idx = idx.Remove(model.ID)
 
 	return s.writeIndex(idx)
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -212,7 +212,7 @@ func TestStoreAPI(t *testing.T) {
 			t.Fatalf("Create model failed: %v", err)
 		}
 
-		if err := s.Write(mdl, []string{"blob-test:latest"}, nil); err != nil {
+		if err := s.Write(mdl, []string{"blob-test:latest", "blob-test:other"}, nil); err != nil {
 			t.Fatalf("Write failed: %v", err)
 		}
 
@@ -249,87 +249,6 @@ func TestStoreAPI(t *testing.T) {
 		// Verify the manifest no longer exists on disk after deletion
 		if _, err := os.Stat(manifestPath); !os.IsNotExist(err) {
 			t.Errorf("Manifest file still exists after deletion: %s", blobPath)
-		}
-	})
-
-	// Test that blobs and model are not removed if there is a tag pointing to it
-	t.Run("BlobsPreservedWithRemainingTags", func(t *testing.T) {
-		// Create a new model with unique content
-		modelContent := []byte("unique content for multi-tag test")
-		modelPath := filepath.Join(tempDir, "multi-tag-test.gguf")
-		if err := os.WriteFile(modelPath, modelContent, 0644); err != nil {
-			t.Fatalf("Failed to create test model file: %v", err)
-		}
-
-		// Calculate the blob hash to find it later
-		hash := sha256.Sum256(modelContent)
-		blobHash := hex.EncodeToString(hash[:])
-		expectedBlobDigest := fmt.Sprintf("sha256:%s", blobHash)
-
-		// Add model to store with multiple tags
-		mdl, err := gguf.NewModel(modelPath)
-		if err != nil {
-			t.Fatalf("Create model failed: %v", err)
-		}
-
-		// Write the model with two tags
-		if err := s.Write(mdl, []string{"multi-tag:v1", "multi-tag:latest"}, nil); err != nil {
-			t.Fatalf("Write failed: %v", err)
-		}
-
-		// Get the blob path
-		blobPath := filepath.Join(storePath, "blobs", "sha256", blobHash)
-
-		// Verify the blob exists on disk
-		if _, err := os.Stat(blobPath); os.IsNotExist(err) {
-			t.Fatalf("Blob file doesn't exist: %s", blobPath)
-		}
-
-		// Delete one of the tags
-		if err := s.Delete("multi-tag:v1"); err != nil {
-			t.Fatalf("Delete failed: %v", err)
-		}
-
-		// Verify the blob still exists on disk after deleting one tag
-		if _, err := os.Stat(blobPath); os.IsNotExist(err) {
-			t.Errorf("Blob file was incorrectly removed: %s", blobPath)
-		}
-
-		// Verify the model is still in the index with the remaining tag
-		models, err := s.List()
-		if err != nil {
-			t.Fatalf("List failed: %v", err)
-		}
-
-		var foundModel bool
-		for _, model := range models {
-			if containsTag(model.Tags, "multi-tag:latest") {
-				foundModel = true
-				// Verify the blob is still associated with the model
-				if len(model.Files) != 2 || model.Files[0] != expectedBlobDigest {
-					t.Errorf("Expected blob %s, got %v", expectedBlobDigest, model.Files)
-				}
-				break
-			}
-		}
-
-		if !foundModel {
-			t.Errorf("Model with tag multi-tag:latest not found after deleting multi-tag:v1")
-		}
-
-		// Verify the model can still be read using the remaining tag
-		remainingModel, err := s.Read("multi-tag:latest")
-		if err != nil {
-			t.Fatalf("Read failed for remaining tag: %v", err)
-		}
-
-		if remainingModel == nil {
-			t.Fatalf("Model is nil despite having a remaining tag")
-		}
-
-		// Verify the remaining tag is present in the model
-		if !containsTag(remainingModel.Tags(), "multi-tag:latest") {
-			t.Errorf("Expected tag multi-tag:latest in model tags, got %v", remainingModel.Tags())
 		}
 	})
 


### PR DESCRIPTION
`DeleteModel` accepts a `force` argument and behaves similarly to `docker rmi --force`

* When there are multiple tags, if the model is deleted by ID, force is required or `distribution.ErrConflict` is returned.
* When there are multiple tags, if the model is deleted by tag, it is merely untagged without deleting the underlying model
* When model has one or zero tags, force is not required and the model is always fully deleted.