### PR TITLE
Handle missing store dir

### DIFF
--- a/distribution/client_test.go
+++ b/distribution/client_test.go
@@ -1018,11 +1018,11 @@ func TestPushProgress(t *testing.T) {
 	if len(lines) < 3 {
 		t.Fatalf("Expected at least 3 progress messages, got %d", len(lines))
 	}
-	if !strings.Contains(lines[len(lines)-2], "Uploaded: 2.00 MB") {
-		t.Fatalf("Expected progress message to contain 'Uploaded: 2.00 MB', got %q", lines[2])
+	if !strings.Contains(lines[len(lines)-2], "Uploaded:") {
+		t.Fatalf("Expected progress message to contain 'Uploaded: x MB', got %q", lines[len(lines)-2])
 	}
 	if !strings.Contains(lines[len(lines)-1], "success") {
-		t.Fatalf("Expected last progress message to contain 'success', got %q", lines[3])
+		t.Fatalf("Expected last progress message to contain 'success', got %q", lines[len(lines)-1])
 	}
 	if err := <-done; err != nil {
 		t.Fatalf("Failed to push model: %v", err)

--- a/internal/store/index.go
+++ b/internal/store/index.go
@@ -105,6 +105,10 @@ func (s *LocalStore) writeIndex(index Index) error {
 		return fmt.Errorf("writing models file: %w", err)
 	}
 
+	if err := s.ensureLayout(); err != nil {
+		return fmt.Errorf("ensuring layout file exists: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/store/index.go
+++ b/internal/store/index.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -111,7 +112,9 @@ func (s *LocalStore) writeIndex(index Index) error {
 func (s *LocalStore) readIndex() (Index, error) {
 	// Read the models index
 	modelsData, err := os.ReadFile(s.indexPath())
-	if err != nil {
+	if errors.Is(err, os.ErrNotExist) {
+		return Index{}, nil
+	} else if err != nil {
 		return Index{}, fmt.Errorf("reading models file: %w", err)
 	}
 

--- a/internal/store/layout.go
+++ b/internal/store/layout.go
@@ -35,6 +35,19 @@ func (s *LocalStore) readLayout() (Layout, error) {
 	return layout, nil
 }
 
+// ensureLayout ensure a layout file exists
+func (s *LocalStore) ensureLayout() error {
+	if _, err := os.Stat(s.layoutPath()); os.IsNotExist(err) {
+		layout := Layout{
+			Version: CurrentVersion,
+		}
+		if err := s.writeLayout(layout); err != nil {
+			return fmt.Errorf("initializing layout file: %w", err)
+		}
+	}
+	return nil
+}
+
 // writeLayout write the layout file
 func (s *LocalStore) writeLayout(layout Layout) error {
 	layoutData, err := json.MarshalIndent(layout, "", "  ")

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -45,14 +45,19 @@ func New(opts Options) (*LocalStore, error) {
 // initialize creates the store directory structure if it doesn't exist
 func (s *LocalStore) initialize() error {
 	// Check if layout.json exists, create if not
-	if _, err := os.Stat(s.layoutPath()); os.IsNotExist(err) {
-		layout := Layout{
-			Version: CurrentVersion,
-		}
-		if err := s.writeLayout(layout); err != nil {
-			return fmt.Errorf("initializing layout file: %w", err)
+	if err := s.ensureLayout(); err != nil {
+		return err
+	}
+
+	// Check if models.json exists, create if not
+	if _, err := os.Stat(s.indexPath()); os.IsNotExist(err) {
+		if err := s.writeIndex(Index{
+			Models: []IndexEntry{},
+		}); err != nil {
+			return fmt.Errorf("initializing index file: %w", err)
 		}
 	}
+
 	return nil
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -53,16 +53,6 @@ func (s *LocalStore) initialize() error {
 			return fmt.Errorf("initializing layout file: %w", err)
 		}
 	}
-
-	// Check if models.json exists, create if not
-	if _, err := os.Stat(s.indexPath()); os.IsNotExist(err) {
-		if err := s.writeIndex(Index{
-			Models: []IndexEntry{},
-		}); err != nil {
-			return fmt.Errorf("initializing index file: %w", err)
-		}
-	}
-
 	return nil
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -34,6 +34,11 @@ func TestStoreAPI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create store: %v", err)
 	}
+	// Everything must handle directory deletion
+	if err := os.RemoveAll(storePath); err != nil {
+		t.Fatalf("Failed to remove store directory: %v", err)
+	}
+
 	model := newTestModel(t)
 	layers, err := model.Layers()
 	if err != nil {


### PR DESCRIPTION
If the entire models directory is deleted, proceed without erroring by recreating index file as needed (and ensure layout exists whenever index is written). This allows a full `rm -rf ~/.docker/models` to recover fro corruption, without restarting model runner. It should be noted that deleting individual files may still produce errors or bad results.

(also fixes flaky test)