### PR TITLE
Add total and pulled bytes to progress messages

### DIFF
--- a/distribution/progress.go
+++ b/distribution/progress.go
@@ -13,8 +13,8 @@ import (
 type ProgressMessage struct {
 	Type    string `json:"type"`    // "progress", "success", or "error"
 	Message string `json:"message"` // Human-readable message
-	Total   int64  `json:"total"`   // Total bytes to transfer
-	Pulled  int64  `json:"pulled"`  // Bytes transferred so far
+	Total   uint64 `json:"total"`   // Total bytes to transfer
+	Pulled  uint64 `json:"pulled"`  // Bytes transferred so far
 }
 
 type reporter struct {
@@ -44,6 +44,14 @@ func newProgressReporter(w io.Writer, msgF progressF) *reporter {
 	}
 }
 
+// safeUint64 converts an int64 to uint64, ensuring the value is non-negative
+func safeUint64(n int64) uint64 {
+	if n < 0 {
+		return 0
+	}
+	return uint64(n)
+}
+
 // updates returns a channel for receiving progress updates. It is the responsibility of the caller to close
 // the channel when they are done sending updates. Should only be called once per reporter instance.
 func (r *reporter) updates() chan<- v1.Update {
@@ -62,7 +70,7 @@ func (r *reporter) updates() chan<- v1.Update {
 			// Only update if enough time has passed or enough bytes downloaded or finished
 			if now.Sub(lastUpdate) >= updateInterval ||
 				bytesDownloaded >= minBytesForUpdate {
-				if err := writeProgress(r.out, r.format(p), p.Total, p.Complete); err != nil {
+				if err := writeProgress(r.out, r.format(p), safeUint64(p.Total), safeUint64(p.Complete)); err != nil {
 					r.err = err
 				}
 				lastUpdate = now
@@ -94,7 +102,7 @@ func writeProgressMessage(w io.Writer, msg ProgressMessage) error {
 }
 
 // writeProgress writes a progress update message
-func writeProgress(w io.Writer, msg string, total, pulled int64) error {
+func writeProgress(w io.Writer, msg string, total, pulled uint64) error {
 	return writeProgressMessage(w, ProgressMessage{
 		Type:    "progress",
 		Message: msg,

--- a/distribution/progress_test.go
+++ b/distribution/progress_test.go
@@ -11,9 +11,11 @@ import (
 func TestProgressMessages(t *testing.T) {
 	t.Run("writeProgress", func(t *testing.T) {
 		var buf bytes.Buffer
-		err := writeProgress(&buf, pullMsg(v1.Update{
+		update := v1.Update{
+			Total:    2 * 1024 * 1024,
 			Complete: 1024 * 1024,
-		}))
+		}
+		err := writeProgress(&buf, pullMsg(update), update.Total, update.Complete)
 		if err != nil {
 			t.Fatalf("Failed to write progress message: %v", err)
 		}
@@ -28,6 +30,12 @@ func TestProgressMessages(t *testing.T) {
 		}
 		if msg.Message != "Downloaded: 1.00 MB" {
 			t.Errorf("Expected message 'Downloaded: 1.00 MB', got '%s'", msg.Message)
+		}
+		if msg.Total != 2*1024*1024 {
+			t.Errorf("Expected total 2MB, got %d", msg.Total)
+		}
+		if msg.Pulled != 1024*1024 {
+			t.Errorf("Expected pulled 1MB, got %d", msg.Pulled)
 		}
 	})
 

--- a/distribution/progress_test.go
+++ b/distribution/progress_test.go
@@ -15,7 +15,7 @@ func TestProgressMessages(t *testing.T) {
 			Total:    2 * 1024 * 1024,
 			Complete: 1024 * 1024,
 		}
-		err := writeProgress(&buf, pullMsg(update), update.Total, update.Complete)
+		err := writeProgress(&buf, pullMsg(update), uint64(update.Total), uint64(update.Complete))
 		if err != nil {
 			t.Fatalf("Failed to write progress message: %v", err)
 		}
@@ -31,10 +31,10 @@ func TestProgressMessages(t *testing.T) {
 		if msg.Message != "Downloaded: 1.00 MB" {
 			t.Errorf("Expected message 'Downloaded: 1.00 MB', got '%s'", msg.Message)
 		}
-		if msg.Total != 2*1024*1024 {
+		if msg.Total != uint64(2*1024*1024) {
 			t.Errorf("Expected total 2MB, got %d", msg.Total)
 		}
-		if msg.Pulled != 1024*1024 {
+		if msg.Pulled != uint64(1024*1024) {
 			t.Errorf("Expected pulled 1MB, got %d", msg.Pulled)
 		}
 	})


### PR DESCRIPTION
Adds Total and Pulled fields to ProgressMessage struct to track the total bytes to transfer and bytes transferred so far.
This enables more detailed progress tracking and better UI feedback during model distribution operations.