### PR TITLE
Includes GGUF metadata into config

### DIFF
--- a/internal/gguf/create.go
+++ b/internal/gguf/create.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	gguf_parser "github.com/gpustack/gguf-parser-go"
+	parser "github.com/gpustack/gguf-parser-go"
 
 	"github.com/docker/model-distribution/internal/partial"
 	"github.com/docker/model-distribution/types"
@@ -41,15 +41,16 @@ func NewModel(path string) (*Model, error) {
 }
 
 func configFromFile(path string) types.Config {
-	ggufFile, err := gguf_parser.ParseGGUFFile(path)
+	gguf, err := parser.ParseGGUFFile(path)
 	if err != nil {
 		return types.Config{} // continue without metadata
 	}
 	return types.Config{
 		Format:       types.FormatGGUF,
-		Parameters:   strings.TrimSpace(ggufFile.Metadata().Parameters.String()),
-		Architecture: strings.TrimSpace(ggufFile.Metadata().Architecture),
-		Quantization: strings.TrimSpace(ggufFile.Metadata().FileType.String()),
-		Size:         strings.TrimSpace(ggufFile.Metadata().Size.String()),
+		Parameters:   strings.TrimSpace(gguf.Metadata().Parameters.String()),
+		Architecture: strings.TrimSpace(gguf.Metadata().Architecture),
+		Quantization: strings.TrimSpace(gguf.Metadata().FileType.String()),
+		Size:         strings.TrimSpace(gguf.Metadata().Size.String()),
+		GGUF:         extractGGUFMetadata(&gguf.Header),
 	}
 }

--- a/internal/gguf/metadata.go
+++ b/internal/gguf/metadata.go
@@ -7,7 +7,7 @@ import (
 	parser "github.com/gpustack/gguf-parser-go"
 )
 
-const maxArraySize = 10
+const maxArraySize = 50
 
 // extractGGUFMetadata converts the GGUF header metadata into a string map.
 func extractGGUFMetadata(header *parser.GGUFHeader) map[string]string {

--- a/internal/gguf/metadata.go
+++ b/internal/gguf/metadata.go
@@ -1,0 +1,95 @@
+package gguf
+
+import (
+	"fmt"
+	"strings"
+
+	parser "github.com/gpustack/gguf-parser-go"
+)
+
+const maxArraySize = 10
+
+// extractGGUFMetadata converts the GGUF header metadata into a string map.
+func extractGGUFMetadata(header *parser.GGUFHeader) map[string]string {
+	metadata := make(map[string]string)
+
+	for _, kv := range header.MetadataKV {
+		if kv.ValueType == parser.GGUFMetadataValueTypeArray {
+			arrayValue := kv.ValueArray()
+			if arrayValue.Len > maxArraySize {
+				continue
+			}
+		}
+		var value string
+		switch kv.ValueType {
+		case parser.GGUFMetadataValueTypeUint8:
+			value = fmt.Sprintf("%d", kv.ValueUint8())
+		case parser.GGUFMetadataValueTypeInt8:
+			value = fmt.Sprintf("%d", kv.ValueInt8())
+		case parser.GGUFMetadataValueTypeUint16:
+			value = fmt.Sprintf("%d", kv.ValueUint16())
+		case parser.GGUFMetadataValueTypeInt16:
+			value = fmt.Sprintf("%d", kv.ValueInt16())
+		case parser.GGUFMetadataValueTypeUint32:
+			value = fmt.Sprintf("%d", kv.ValueUint32())
+		case parser.GGUFMetadataValueTypeInt32:
+			value = fmt.Sprintf("%d", kv.ValueInt32())
+		case parser.GGUFMetadataValueTypeUint64:
+			value = fmt.Sprintf("%d", kv.ValueUint64())
+		case parser.GGUFMetadataValueTypeInt64:
+			value = fmt.Sprintf("%d", kv.ValueInt64())
+		case parser.GGUFMetadataValueTypeFloat32:
+			value = fmt.Sprintf("%f", kv.ValueFloat32())
+		case parser.GGUFMetadataValueTypeFloat64:
+			value = fmt.Sprintf("%f", kv.ValueFloat64())
+		case parser.GGUFMetadataValueTypeBool:
+			value = fmt.Sprintf("%t", kv.ValueBool())
+		case parser.GGUFMetadataValueTypeString:
+			value = kv.ValueString()
+		case parser.GGUFMetadataValueTypeArray:
+			value = handleArray(kv.ValueArray())
+		default:
+			value = fmt.Sprintf("[unknown type %d]", kv.ValueType)
+		}
+		metadata[kv.Key] = value
+	}
+
+	return metadata
+}
+
+// handleArray processes an array value and returns its string representation
+func handleArray(arrayValue parser.GGUFMetadataKVArrayValue) string {
+	var values []string
+	for _, v := range arrayValue.Array {
+		switch arrayValue.Type {
+		case parser.GGUFMetadataValueTypeUint8:
+			values = append(values, fmt.Sprintf("%d", v.(uint8)))
+		case parser.GGUFMetadataValueTypeInt8:
+			values = append(values, fmt.Sprintf("%d", v.(int8)))
+		case parser.GGUFMetadataValueTypeUint16:
+			values = append(values, fmt.Sprintf("%d", v.(uint16)))
+		case parser.GGUFMetadataValueTypeInt16:
+			values = append(values, fmt.Sprintf("%d", v.(int16)))
+		case parser.GGUFMetadataValueTypeUint32:
+			values = append(values, fmt.Sprintf("%d", v.(uint32)))
+		case parser.GGUFMetadataValueTypeInt32:
+			values = append(values, fmt.Sprintf("%d", v.(int32)))
+		case parser.GGUFMetadataValueTypeUint64:
+			values = append(values, fmt.Sprintf("%d", v.(uint64)))
+		case parser.GGUFMetadataValueTypeInt64:
+			values = append(values, fmt.Sprintf("%d", v.(int64)))
+		case parser.GGUFMetadataValueTypeFloat32:
+			values = append(values, fmt.Sprintf("%f", v.(float32)))
+		case parser.GGUFMetadataValueTypeFloat64:
+			values = append(values, fmt.Sprintf("%f", v.(float64)))
+		case parser.GGUFMetadataValueTypeBool:
+			values = append(values, fmt.Sprintf("%t", v.(bool)))
+		case parser.GGUFMetadataValueTypeString:
+			values = append(values, v.(string))
+		default:
+			// Do nothing
+		}
+	}
+
+	return strings.Join(values, ", ")
+}

--- a/internal/gguf/model_test.go
+++ b/internal/gguf/model_test.go
@@ -35,6 +35,38 @@ func TestGGUF(t *testing.T) {
 			if cfg.Size != "864 B" {
 				t.Fatalf("Unexpected quantization: got %s expected %s", cfg.Quantization, "Unknown")
 			}
+
+			// Test GGUF metadata
+			if cfg.GGUF == nil {
+				t.Fatal("Expected GGUF metadata to be present")
+			}
+			// Verify all expected metadata fields from the example https://github.com/ggml-org/llama.cpp/blob/44cd8d91ff2c9e4a0f2e3151f8d6f04c928e2571/examples/gguf/gguf.cpp#L24
+			expectedParams := map[string]string{
+				"some.parameter.uint8":   "18",                   // 0x12
+				"some.parameter.int8":    "-19",                  // -0x13
+				"some.parameter.uint16":  "4660",                 // 0x1234
+				"some.parameter.int16":   "-4661",                // -0x1235
+				"some.parameter.uint32":  "305419896",            // 0x12345678
+				"some.parameter.int32":   "-305419897",           // -0x12345679
+				"some.parameter.float32": "0.123457",             // 0.123456789f
+				"some.parameter.uint64":  "1311768467463790320",  // 0x123456789abcdef0
+				"some.parameter.int64":   "-1311768467463790321", // -0x123456789abcdef1
+				"some.parameter.float64": "0.123457",             // 0.1234567890123456789
+				"some.parameter.bool":    "true",
+				"some.parameter.string":  "hello world",
+				"some.parameter.arr.i16": "1, 2, 3, 4",
+			}
+
+			for key, expectedValue := range expectedParams {
+				actualValue, ok := cfg.GGUF[key]
+				if !ok {
+					t.Errorf("Expected key '%s' in GGUF metadata", key)
+					continue
+				}
+				if actualValue != expectedValue {
+					t.Errorf("For key '%s': expected value '%s', got '%s'", key, expectedValue, actualValue)
+				}
+			}
 		})
 
 		t.Run("TestDescriptor", func(t *testing.T) {

--- a/types/config.go
+++ b/types/config.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
@@ -38,11 +38,12 @@ type ConfigFile struct {
 
 // Config describes the model.
 type Config struct {
-	Format       Format `json:"format,omitempty"`
-	Quantization string `json:"quantization,omitempty"`
-	Parameters   string `json:"parameters,omitempty"`
-	Architecture string `json:"architecture,omitempty"`
-	Size         string `json:"size,omitempty"`
+	Format       Format            `json:"format,omitempty"`
+	Quantization string            `json:"quantization,omitempty"`
+	Parameters   string            `json:"parameters,omitempty"`
+	Architecture string            `json:"architecture,omitempty"`
+	Size         string            `json:"size,omitempty"`
+	GGUF         map[string]string `json:"gguf,omitempty"`
 }
 
 // Descriptor provides metadata about the provenance of the model.


### PR DESCRIPTION
Includes GGUF metadata into config:
I considered these 3 options:

1. Ignore fields with more than X (50) elements: [example](https://oci.dag.dev/?blob=ignaciolopezluna020/gguf@sha256:dfb6cc6d0fdbf7323d9176fd2d0862c93003e434485346ec194f385b6c98212e&mt=application%2Fvnd.docker.ai.model.config.v0.1%2Bjson&size=1953&manifest=ignaciolopezluna020/gguf@sha256:307129b2aa40b5aa66dfc8b23310b2c20bb1ef4175b2edf95882a97ae8bc7bf5)
2. Show all fields: [example](https://oci.dag.dev/?blob=ignaciolopezluna020/gguf@sha256:977759ec4c5e088dc01897eed9a7de6fc02ed567939dbddab1b8a3a3a74c1994&mt=application%2Fvnd.docker.ai.model.config.v0.1%2Bjson&size=1133477&manifest=ignaciolopezluna020/gguf:all@sha256:8b58ae83af2e0253c02d3b051c852e8cc6fe1c7221240ce99e9220f2a855a066)
3. The gguf parser has this option `parser.SkipLargeMetadata()` which seems to ignore all arrays (even small ones, like tags or languages: [example](https://oci.dag.dev/?blob=ignaciolopezluna020/gguf@sha256:538992308538fff00d0b3278589efb75205cd1750008e7e974eaa936f774bec9&mt=application%2Fvnd.docker.ai.model.config.v0.1%2Bjson&size=1984&manifest=ignaciolopezluna020/gguf:skip@sha256:ccfcdaa86bae355dbc39befcff088f7eafb004261d65f55b6d9772b9cb0d43df)

I chosen `1` as it seems to me the right balance between including useful fields without overcharging the config