### PR TITLE
Use local converter image for builds

### DIFF
--- a/scripts/model-push/llama-converter/Dockerfile
+++ b/scripts/model-push/llama-converter/Dockerfile
@@ -1,4 +1,4 @@
-FROM ignaciolopezluna020/llama.cpp:cpu
+FROM ghcr.io/ggml-org/llama.cpp:full-b5227
 
 # Install git-lfs to handle Hugging Face repositories
 RUN apt-get update && apt-get install -y git-lfs && \

--- a/scripts/model-push/push-model.sh
+++ b/scripts/model-push/push-model.sh
@@ -144,10 +144,11 @@ echo
 
 # Step 1: Run Docker container to convert the model from Hugging Face
 echo "Step 1: Converting model from Hugging Face..."
+docker build -t docker/llama-converter:latest llama-converter
 docker run --rm \
     -e HUGGINGFACE_TOKEN="$HF_TOKEN" \
     -v "$MODELS_DIR:/models" \
-    ignaciolopezluna020/llama-converter:latest \
+    docker/llama-converter:latest \
     --from-hf "$HF_MODEL" --quantization "$QUANTIZATION"
 
 # Get the model name from the HF_MODEL


### PR DESCRIPTION
Always build and utilize a local converter image based on the official upstream version. This change prepares for future updates to newer models that require an updated llama.cpp version.
Furthermore we avoid relying on privately hosted images.

This specific change now supports converting Qwen3 models.