### PR TITLE
Add Model Capabilities Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,12 @@ run-pull:
 
 run-package:
 	@echo "Pushing model ${SOURCE} to ${TAG}..."
-	@${GOBIN}/${BINARY_NAME} --store-path ${STORE_PATH} package ${SOURCE} ${TAG} \
+	@${GOBIN}/${BINARY_NAME} --store-path ${STORE_PATH} package \
 		${LICENSE:+--licenses ${LICENSE}} \
 		--input ${INPUT_TYPES} \
 		--output ${OUTPUT_TYPES} \
-		${TOOL_USAGE:+--tool-usage}
+		${TOOL_USAGE:+--tool-usage} \
+		${SOURCE} ${TAG}
 
 run-list:
 	@echo "Listing models..."

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ GOBIN=$(GOBASE)/bin
 SOURCE?=
 TAG?=
 STORE_PATH?=./model-store
+LICENSE?=
+INPUT_TYPES?=text
+OUTPUT_TYPES?=text
+TOOL_USAGE?=false
 
 # Use linker flags to provide version/build information
 LDFLAGS=-ldflags "-X main.Version=${VERSION}"
@@ -48,7 +52,11 @@ run-pull:
 
 run-package:
 	@echo "Pushing model ${SOURCE} to ${TAG}..."
-	@${GOBIN}/${BINARY_NAME} --store-path ${STORE_PATH} package ${SOURCE} ${TAG} ${LICENSE:+--license ${LICENSE}}
+	@${GOBIN}/${BINARY_NAME} --store-path ${STORE_PATH} package ${SOURCE} ${TAG} \
+		${LICENSE:+--licenses ${LICENSE}} \
+		--input ${INPUT_TYPES} \
+		--output ${OUTPUT_TYPES} \
+		${TOOL_USAGE:+--tool-usage}
 
 run-list:
 	@echo "Listing models..."
@@ -77,7 +85,9 @@ help:
 	@echo "  test             - Run unit tests"
 	@echo "  clean            - Clean build artifacts"
 	@echo "  run-pull         - Pull a model (TAG=registry/model:tag)"
-	@echo "  run-package      - Package and push a model (SOURCE=path/to/model.gguf TAG=registry/model:tag LICENSE=path/to/license.txt)"
+	@echo "  run-package      - Package and push a model (SOURCE=path/to/model.gguf TAG=registry/model:tag)"
+	@echo "                    Optional: LICENSE=path/to/license.txt"
+	@echo "                    Optional: INPUT_TYPES=text,image OUTPUT_TYPES=text,audio TOOL_USAGE=true"
 	@echo "  run-list         - List all models"
 	@echo "  run-get          - Get model info (TAG=registry/model:tag)"
 	@echo "  run-get-path     - Get model path (TAG=registry/model:tag)"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,34 @@ make build
 # Package a model with license files and push to a registry
 ./bin/model-distribution-tool package --licenses license1.txt --licenses license2.txt ./model.gguf registry.example.com/models/llama:v1.0
 
+# Package a model with specific capabilities
+# Example 1: Text-only model
+./bin/model-distribution-tool package \
+    --input text \
+    --output text \
+    ./model.gguf registry.example.com/models/llama:v1.0
+
+# Example 2: Multimodal model that can handle text and images
+./bin/model-distribution-tool package \
+    --input text,image \
+    --output text \
+    ./model.gguf registry.example.com/models/multimodal:v1.0
+
+# Example 3: Model with tool usage capability
+./bin/model-distribution-tool package \
+    --input text \
+    --output text \
+    --tool-usage \
+    ./model.gguf registry.example.com/models/assistant:v1.0
+
+# Example 4: Complete example with all options
+./bin/model-distribution-tool package \
+    --licenses license.txt \
+    --input text,image \
+    --output text,audio \
+    --tool-usage \
+    ./model.gguf registry.example.com/models/multimodal:v1.0
+
 # Push a model from the content store to the registry
 ./bin/model-distribution-tool push registry.example.com/models/llama:v1.0
 
@@ -65,6 +93,7 @@ For more information about the CLI tool, run:
 import (
     "context"
     "github.com/docker/model-distribution/pkg/distribution"
+    "github.com/docker/model-distribution/types"
 )
 
 // Create a new client
@@ -117,3 +146,13 @@ if err != nil {
     // Handle error
 }
 ```
+
+### Model Capabilities
+
+The tool supports specifying model capabilities through the following options:
+
+- `--input`: Comma-separated list of input types the model can handle
+  - Valid types: `text`, `embedding`, `image`, `audio`, `video`
+- `--output`: Comma-separated list of output types the model can produce
+  - Valid types: `text`, `embedding`, `image`, `audio`, `video`
+- `--tool-usage`: Flag indicating if the model can use tools

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -17,8 +17,8 @@ type Builder struct {
 }
 
 // FromGGUF returns a *Builder that builds a model artifacts from a GGUF file
-func FromGGUF(path string) (*Builder, error) {
-	mdl, err := gguf.NewModel(path)
+func FromGGUF(path string, capabilities *types.Capabilities) (*Builder, error) {
+	mdl, err := gguf.NewModel(path, capabilities)
 	if err != nil {
 		return nil, err
 	}

--- a/distribution/client_test.go
+++ b/distribution/client_test.go
@@ -60,7 +60,7 @@ func TestClientPullModel(t *testing.T) {
 		t.Fatalf("Failed to read test model file: %v", err)
 	}
 
-	model, err := gguf.NewModel(testGGUFFile)
+	model, err := gguf.NewModel(testGGUFFile, nil)
 	if err != nil {
 		t.Fatalf("Failed to create model: %v", err)
 	}
@@ -200,7 +200,7 @@ func TestClientPullModel(t *testing.T) {
 		}
 
 		// Use the dummy.gguf file from assets directory
-		mdl, err := gguf.NewModel(testGGUFFile)
+		mdl, err := gguf.NewModel(testGGUFFile, nil)
 		if err != nil {
 			t.Fatalf("Failed to create model: %v", err)
 		}
@@ -523,7 +523,7 @@ func TestClientGetModel(t *testing.T) {
 	}
 
 	// Create model from test GGUF file
-	model, err := gguf.NewModel(testGGUFFile)
+	model, err := gguf.NewModel(testGGUFFile, nil)
 	if err != nil {
 		t.Fatalf("Failed to create model: %v", err)
 	}
@@ -588,7 +588,7 @@ func TestClientListModels(t *testing.T) {
 		t.Fatalf("Failed to write test model file: %v", err)
 	}
 
-	mdl, err := gguf.NewModel(modelFile)
+	mdl, err := gguf.NewModel(modelFile, nil)
 	if err != nil {
 		t.Fatalf("Failed to create model: %v", err)
 	}
@@ -606,7 +606,7 @@ func TestClientListModels(t *testing.T) {
 	if err := os.WriteFile(modelFile2, modelContent2, 0644); err != nil {
 		t.Fatalf("Failed to write test model file: %v", err)
 	}
-	mdl2, err := gguf.NewModel(modelFile2)
+	mdl2, err := gguf.NewModel(modelFile2, nil)
 	if err != nil {
 		t.Fatalf("Failed to create model: %v", err)
 	}
@@ -847,7 +847,7 @@ func TestPush(t *testing.T) {
 	tag := uri.Host + "/incomplete-test/model:v1.0.0"
 
 	// Write a test model to the store with the given tag
-	mdl, err := gguf.NewModel(testGGUFFile)
+	mdl, err := gguf.NewModel(testGGUFFile, nil)
 	if err != nil {
 		t.Fatalf("Failed to create model: %v", err)
 	}
@@ -922,7 +922,7 @@ func TestPushProgress(t *testing.T) {
 	}
 	defer os.Remove(path)
 
-	mdl, err := gguf.NewModel(path)
+	mdl, err := gguf.NewModel(path, nil)
 	if err != nil {
 		t.Fatalf("Failed to create model: %v", err)
 	}
@@ -977,7 +977,7 @@ func TestTag(t *testing.T) {
 	}
 
 	// Create a test model
-	model, err := gguf.NewModel(testGGUFFile)
+	model, err := gguf.NewModel(testGGUFFile, nil)
 	if err != nil {
 		t.Fatalf("Failed to create model: %v", err)
 	}
@@ -1069,7 +1069,7 @@ func writeToRegistry(source, reference string) error {
 	}
 
 	// Create image with layer
-	mdl, err := gguf.NewModel(source)
+	mdl, err := gguf.NewModel(source, nil)
 	if err != nil {
 		return fmt.Errorf("new model: %w", err)
 	}

--- a/distribution/delete_test.go
+++ b/distribution/delete_test.go
@@ -23,7 +23,7 @@ func TestDeleteModel(t *testing.T) {
 	}
 
 	// Use the dummy.gguf file from assets directory
-	mdl, err := gguf.NewModel(testGGUFFile)
+	mdl, err := gguf.NewModel(testGGUFFile, nil)
 	if err != nil {
 		t.Fatalf("Failed to create model: %v", err)
 	}

--- a/distribution/ecr_test.go
+++ b/distribution/ecr_test.go
@@ -41,7 +41,7 @@ func TestECRIntegration(t *testing.T) {
 	}
 
 	t.Run("Push", func(t *testing.T) {
-		mdl, err := gguf.NewModel(testGGUFFile)
+		mdl, err := gguf.NewModel(testGGUFFile, nil)
 		if err != nil {
 			t.Fatalf("Failed to create model: %v", err)
 		}

--- a/distribution/gar_test.go
+++ b/distribution/gar_test.go
@@ -42,7 +42,7 @@ func TestGARIntegration(t *testing.T) {
 
 	// Test push to GAR
 	t.Run("Push", func(t *testing.T) {
-		mdl, err := gguf.NewModel(testGGUFFile)
+		mdl, err := gguf.NewModel(testGGUFFile, nil)
 		if err != nil {
 			t.Fatalf("Failed to create model: %v", err)
 		}

--- a/internal/gguf/model_test.go
+++ b/internal/gguf/model_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestGGUF(t *testing.T) {
 	t.Run("TestGGUFModel", func(t *testing.T) {
-		mdl, err := gguf.NewModel(filepath.Join("..", "..", "assets", "dummy.gguf"))
+		mdl, err := gguf.NewModel(filepath.Join("..", "..", "assets", "dummy.gguf"), nil)
 		if err != nil {
 			t.Fatalf("Failed to create model: %v", err)
 		}

--- a/internal/mutate/model.go
+++ b/internal/mutate/model.go
@@ -27,7 +27,7 @@ func (m *model) ID() (string, error) {
 }
 
 func (m *model) Config() (types.Config, error) {
-	return partial.Config(m.base)
+	return partial.Config(m)
 }
 
 func (m *model) MediaType() (ggcr.MediaType, error) {

--- a/internal/mutate/model.go
+++ b/internal/mutate/model.go
@@ -27,7 +27,7 @@ func (m *model) ID() (string, error) {
 }
 
 func (m *model) Config() (types.Config, error) {
-	return partial.Config(m)
+	return partial.Config(m.base)
 }
 
 func (m *model) MediaType() (ggcr.MediaType, error) {

--- a/internal/mutate/mutate_test.go
+++ b/internal/mutate/mutate_test.go
@@ -14,7 +14,13 @@ import (
 )
 
 func TestAppendLayer(t *testing.T) {
-	mdl1, err := gguf.NewModel(filepath.Join("..", "..", "assets", "dummy.gguf"))
+	mdl1, err := gguf.NewModel(filepath.Join("..", "..", "assets", "dummy.gguf"), &types.Capabilities{
+		IO: types.IOTypes{
+			Input:  []string{types.IOTypeText},
+			Output: []string{types.IOTypeText},
+		},
+		ToolUsage: false,
+	})
 	if err != nil {
 		t.Fatalf("Failed to create model: %v", err)
 	}
@@ -30,9 +36,7 @@ func TestAppendLayer(t *testing.T) {
 	mdl2 := mutate.AppendLayers(mdl1,
 		static.NewLayer([]byte("some layer content"), "application/vnd.example.some.media.type"),
 	)
-	if err != nil {
-		t.Fatalf("Failed to create layer: %v", err)
-	}
+
 	if mdl2 == nil {
 		t.Fatal("Expected non-nil model")
 	}
@@ -61,7 +65,13 @@ func TestAppendLayer(t *testing.T) {
 }
 
 func TestConfigMediaTypes(t *testing.T) {
-	mdl1, err := gguf.NewModel(filepath.Join("..", "..", "assets", "dummy.gguf"))
+	mdl1, err := gguf.NewModel(filepath.Join("..", "..", "assets", "dummy.gguf"), &types.Capabilities{
+		IO: types.IOTypes{
+			Input:  []string{types.IOTypeText},
+			Output: []string{types.IOTypeText},
+		},
+		ToolUsage: false,
+	})
 	if err != nil {
 		t.Fatalf("Failed to create model: %v", err)
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -212,7 +212,7 @@ func TestStoreAPI(t *testing.T) {
 		blobHash := hex.EncodeToString(hash[:])
 
 		// Add model to store with a unique tag
-		mdl, err := gguf.NewModel(modelPath)
+		mdl, err := gguf.NewModel(modelPath, nil)
 		if err != nil {
 			t.Fatalf("Create model failed: %v", err)
 		}
@@ -272,7 +272,7 @@ func TestStoreAPI(t *testing.T) {
 		expectedBlobDigest := fmt.Sprintf("sha256:%s", blobHash)
 
 		// Create first model with the shared content
-		model1, err := gguf.NewModel(sharedModelPath)
+		model1, err := gguf.NewModel(sharedModelPath, nil)
 		if err != nil {
 			t.Fatalf("Create first model failed: %v", err)
 		}
@@ -283,7 +283,7 @@ func TestStoreAPI(t *testing.T) {
 		}
 
 		// Create second model with the same shared content
-		model2, err := gguf.NewModel(sharedModelPath)
+		model2, err := gguf.NewModel(sharedModelPath, nil)
 		if err != nil {
 			t.Fatalf("Create second model failed: %v", err)
 		}
@@ -426,7 +426,7 @@ func TestIncompleteFileHandling(t *testing.T) {
 	}
 
 	// Create a model
-	mdl, err := gguf.NewModel(modelPath)
+	mdl, err := gguf.NewModel(modelPath, nil)
 	if err != nil {
 		t.Fatalf("Create model failed: %v", err)
 	}
@@ -469,7 +469,7 @@ func newTestModel(t *testing.T) types.ModelArtifact {
 	var mdl types.ModelArtifact
 	var err error
 
-	mdl, err = gguf.NewModel(filepath.Join("testdata", "dummy.gguf"))
+	mdl, err = gguf.NewModel(filepath.Join("testdata", "dummy.gguf"), nil)
 	if err != nil {
 		t.Fatalf("failed to create model from gguf file: %v", err)
 	}

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -1,0 +1,197 @@
+package types
+
+import (
+	"testing"
+)
+
+func TestIOTypesValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		io      IOTypes
+		wantErr bool
+	}{
+		{
+			name: "valid text model",
+			io: IOTypes{
+				Input:  []string{IOTypeText},
+				Output: []string{IOTypeText},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid multimodal model",
+			io: IOTypes{
+				Input:  []string{IOTypeText, IOTypeImage},
+				Output: []string{IOTypeText},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid input type",
+			io: IOTypes{
+				Input:  []string{"invalid"},
+				Output: []string{IOTypeText},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid output type",
+			io: IOTypes{
+				Input:  []string{IOTypeText},
+				Output: []string{"invalid"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate input type",
+			io: IOTypes{
+				Input:  []string{IOTypeText, IOTypeText},
+				Output: []string{IOTypeText},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate output type",
+			io: IOTypes{
+				Input:  []string{IOTypeText},
+				Output: []string{IOTypeText, IOTypeText},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty input",
+			io: IOTypes{
+				Input:  []string{},
+				Output: []string{IOTypeText},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty output",
+			io: IOTypes{
+				Input:  []string{IOTypeText},
+				Output: []string{},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.io.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IOTypes.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCapabilitiesValidate(t *testing.T) {
+	tests := []struct {
+		name         string
+		capabilities *Capabilities
+		wantErr      bool
+	}{
+		{
+			name: "valid capabilities",
+			capabilities: &Capabilities{
+				IO: IOTypes{
+					Input:  []string{IOTypeText},
+					Output: []string{IOTypeText},
+				},
+				ToolUsage: true,
+			},
+			wantErr: false,
+		},
+		{
+			name:         "nil capabilities",
+			capabilities: nil,
+			wantErr:      true,
+		},
+		{
+			name: "invalid IO types",
+			capabilities: &Capabilities{
+				IO: IOTypes{
+					Input:  []string{"invalid"},
+					Output: []string{IOTypeText},
+				},
+				ToolUsage: true,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.capabilities.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Capabilities.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewCapabilities(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     []string
+		output    []string
+		toolUsage bool
+		wantErr   bool
+		wantNil   bool
+	}{
+		{
+			name:      "valid capabilities",
+			input:     []string{IOTypeText},
+			output:    []string{IOTypeText},
+			toolUsage: true,
+			wantErr:   false,
+			wantNil:   false,
+		},
+		{
+			name:      "invalid input type",
+			input:     []string{"invalid"},
+			output:    []string{IOTypeText},
+			toolUsage: true,
+			wantErr:   true,
+			wantNil:   true,
+		},
+		{
+			name:      "invalid output type",
+			input:     []string{IOTypeText},
+			output:    []string{"invalid"},
+			toolUsage: true,
+			wantErr:   true,
+			wantNil:   true,
+		},
+		{
+			name:      "duplicate input type",
+			input:     []string{IOTypeText, IOTypeText},
+			output:    []string{IOTypeText},
+			toolUsage: true,
+			wantErr:   true,
+			wantNil:   true,
+		},
+		{
+			name:      "duplicate output type",
+			input:     []string{IOTypeText},
+			output:    []string{IOTypeText, IOTypeText},
+			toolUsage: true,
+			wantErr:   true,
+			wantNil:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewCapabilities(tt.input, tt.output, tt.toolUsage)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewCapabilities() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if (got == nil) != tt.wantNil {
+				t.Errorf("NewCapabilities() got = %v, wantNil %v", got, tt.wantNil)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces support for specifying model capabilities during packaging, allowing users to define input/output types and tool usage capabilities for their models.

Added new command-line flags to the package command:
`--input`: Comma-separated list of input types (text, embedding, image, audio, video)
`--output`: Comma-separated list of output types (text, embedding, image, audio, video)
`--tool-usage`: Flag to enable tool usage support
