### PR TITLE
Do not assume a model always has a tag

### DIFF
--- a/distribution/client.go
+++ b/distribution/client.go
@@ -200,7 +200,7 @@ func (c *Client) ListModels() ([]types.Model, error) {
 		// Read the models
 		model, err := c.store.Read(modelInfo.ID)
 		if err != nil {
-			c.log.Warnf("Failed to read model with tag %s: %v", modelInfo.Tags[0], err)
+			c.log.Warnf("Failed to read model with ID %s: %v", modelInfo.ID, err)
 			continue
 		}
 		result = append(result, model)


### PR DESCRIPTION
In case of error reading store to list models, the model distribution will panic if there is a model without tag. This PR fixed that.