### PR TITLE
Fix context of GHA

### DIFF
--- a/.github/actions/package-model/action.yml
+++ b/.github/actions/package-model/action.yml
@@ -57,7 +57,7 @@ runs:
     - name: Build and push model
       uses: docker/build-push-action@v6
       with:
-        context: .
+        context: ${{ github.action_path }}
         platforms: ${{ inputs.platforms }}
         build-args: |
           GGUF_FILE_URL=${{ inputs.gguf-file-url }}


### PR DESCRIPTION
In composite actions, the working directory `context` is not automatically set to the directory where the action lives. Instead, it points to the calling workflow’s root, which doesn’t have a Dockerfile, hence [the error](https://github.com/docker/unsloth-dockerhub/actions/runs/15927307713/job/44933809958) 