### PR TITLE
Calculate imageSize by adding the size of all layers, and include it in the progress message

### DIFF
--- a/internal/progress/reporter_test.go
+++ b/internal/progress/reporter_test.go
@@ -58,10 +58,10 @@ func TestMessages(t *testing.T) {
 		update := v1.Update{
 			Complete: 1024 * 1024,
 		}
-		layer := newMockLayer(2016)
-		size := layer.size
+		layer1 := newMockLayer(2016)
+		layer2 := newMockLayer(1)
 
-		err := WriteProgress(&buf, PullMsg(update), uint64(size), uint64(update.Complete), layer.diffID)
+		err := WriteProgress(&buf, PullMsg(update), uint64(layer1.size+layer2.size), uint64(layer1.size), uint64(update.Complete), layer1.diffID)
 		if err != nil {
 			t.Fatalf("Failed to write progress message: %v", err)
 		}
@@ -76,6 +76,9 @@ func TestMessages(t *testing.T) {
 		}
 		if msg.Message != "Downloaded: 1.00 MB" {
 			t.Errorf("Expected message 'Downloaded: 1.00 MB', got '%s'", msg.Message)
+		}
+		if msg.Total != uint64(2017) {
+			t.Errorf("Expected total 2017, got %d", msg.Total)
 		}
 		if msg.Pulled != uint64(1024*1024) {
 			t.Errorf("Expected pulled 1MB, got %d", msg.Pulled)
@@ -208,7 +211,7 @@ func TestProgressEmissionScenarios(t *testing.T) {
 			var buf bytes.Buffer
 			layer := newMockLayer(tt.layerSize)
 
-			reporter := NewProgressReporter(&buf, PullMsg, layer)
+			reporter := NewProgressReporter(&buf, PullMsg, 0, layer)
 			updates := reporter.Updates()
 
 			// Send updates with delays

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -188,17 +188,25 @@ func (s *LocalStore) Write(mdl v1.Image, tags []string, w io.Writer) error {
 		return fmt.Errorf("writing config file: %w", err)
 	}
 
-	// Write the blobs
 	layers, err := mdl.Layers()
 	if err != nil {
 		return fmt.Errorf("getting layers: %w", err)
+	}
+
+	imageSize := int64(0)
+	for _, layer := range layers {
+		size, err := layer.Size()
+		if err != nil {
+			return fmt.Errorf("getting layer size: %w", err)
+		}
+		imageSize += size
 	}
 
 	for _, layer := range layers {
 		var pr *progress.Reporter
 		var progressChan chan<- v1.Update
 		if w != nil {
-			pr = progress.NewProgressReporter(w, progress.PullMsg, layer)
+			pr = progress.NewProgressReporter(w, progress.PullMsg, imageSize, layer)
 			progressChan = pr.Updates()
 		}
 

--- a/registry/client.go
+++ b/registry/client.go
@@ -132,7 +132,20 @@ func (c *Client) NewTarget(tag string) (*Target, error) {
 }
 
 func (t *Target) Write(ctx context.Context, model types.ModelArtifact, progressWriter io.Writer) error {
-	pr := progress.NewProgressReporter(progressWriter, progress.PushMsg, nil)
+	layers, err := model.Layers()
+	if err != nil {
+		return fmt.Errorf("getting layers: %w", err)
+	}
+
+	imageSize := int64(0)
+	for _, layer := range layers {
+		size, err := layer.Size()
+		if err != nil {
+			return fmt.Errorf("getting layer size: %w", err)
+		}
+		imageSize += size
+	}
+	pr := progress.NewProgressReporter(progressWriter, progress.PushMsg, imageSize, nil)
 	defer pr.Wait()
 
 	// Set up authentication options


### PR DESCRIPTION
The total size of a model was not included in the progress message. This PR fixes that by calculating the total adding the size of all the layers.
It reuses the previously deprecated `Total`.

There are still things to improve about how the progress is reported:
- It would be great if we can include the total progress, not just the progress per layer
- It would be great if we can include the total in the success message (not as string but as uint)

These can be done in follow up PRs, as they require more changes.

Note: I've deprecated the  `Message` field as this message should be defined by the clients of the lib