### PR TITLE
distribution client: return untagged tags on delete

### DIFF
--- a/cmd/mdltool/main.go
+++ b/cmd/mdltool/main.go
@@ -380,7 +380,7 @@ func cmdRm(client *distribution.Client, args []string) int {
 
 	reference := args[0]
 
-	if err := client.DeleteModel(reference, force); err != nil {
+	if _, err := client.DeleteModel(reference, force); err != nil {
 		fmt.Fprintf(os.Stderr, "Error removing model: %v\n", err)
 		return 1
 	}

--- a/distribution/client_test.go
+++ b/distribution/client_test.go
@@ -246,7 +246,7 @@ func TestClientPullModel(t *testing.T) {
 		}
 
 		// Delete the local model to force a pull
-		if err := client.DeleteModel(tag, false); err != nil {
+		if _, err := client.DeleteModel(tag, false); err != nil {
 			t.Fatalf("Failed to delete model: %v", err)
 		}
 
@@ -866,7 +866,7 @@ func TestPush(t *testing.T) {
 	}
 
 	// Delete local copy (so we can test pulling)
-	if err := client.DeleteModel(tag, false); err != nil {
+	if _, err := client.DeleteModel(tag, false); err != nil {
 		t.Fatalf("Failed to delete model: %v", err)
 	}
 

--- a/distribution/delete_test.go
+++ b/distribution/delete_test.go
@@ -122,7 +122,7 @@ func TestDeleteModel(t *testing.T) {
 			}
 
 			// Attempt to delete the model and check for expected error
-			if err := client.DeleteModel(tc.ref, tc.force); !errors.Is(err, tc.expectedErr) {
+			if _, err := client.DeleteModel(tc.ref, tc.force); !errors.Is(err, tc.expectedErr) {
 				t.Fatalf("Expected error %v, got: %v", tc.expectedErr, err)
 			}
 			if tc.expectedErr != nil {

--- a/distribution/delete_test.go
+++ b/distribution/delete_test.go
@@ -3,6 +3,7 @@ package distribution
 import (
 	"errors"
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/docker/model-distribution/internal/gguf"
@@ -122,11 +123,26 @@ func TestDeleteModel(t *testing.T) {
 			}
 
 			// Attempt to delete the model and check for expected error
-			if _, err := client.DeleteModel(tc.ref, tc.force); !errors.Is(err, tc.expectedErr) {
+			out, err := client.DeleteModel(tc.ref, tc.force)
+			if !errors.Is(err, tc.expectedErr) {
 				t.Fatalf("Expected error %v, got: %v", tc.expectedErr, err)
 			}
 			if tc.expectedErr != nil {
 				return
+			}
+
+			expectedOut := ""
+			if slices.Contains(tc.tags, tc.ref) {
+				// tc.ref is a tag
+				expectedOut = "Untagged: " + tc.ref + "\n"
+			} else {
+				// tc.ref is an ID
+				for _, tag := range tc.tags {
+					expectedOut += "Untagged: " + tag + "\n"
+				}
+			}
+			if expectedOut != out {
+				t.Fatalf("Expected output %q, got: %q", expectedOut, out)
 			}
 
 			// Verify model ref unreachable by ref (untagged)

--- a/distribution/ecr_test.go
+++ b/distribution/ecr_test.go
@@ -51,7 +51,7 @@ func TestECRIntegration(t *testing.T) {
 		if err := client.PushModel(context.Background(), ecrTag, nil); err != nil {
 			t.Fatalf("Failed to push model to ECR: %v", err)
 		}
-		if err := client.DeleteModel(ecrTag, false); err != nil { // cleanup
+		if _, err := client.DeleteModel(ecrTag, false); err != nil { // cleanup
 			t.Fatalf("Failed to delete model from store: %v", err)
 		}
 	})

--- a/distribution/gar_test.go
+++ b/distribution/gar_test.go
@@ -52,7 +52,7 @@ func TestGARIntegration(t *testing.T) {
 		if err := client.PushModel(context.Background(), garTag, nil); err != nil {
 			t.Fatalf("Failed to push model to ECR: %v", err)
 		}
-		if err := client.DeleteModel(garTag, false); err != nil { // cleanup
+		if _, err := client.DeleteModel(garTag, false); err != nil { // cleanup
 			t.Fatalf("Failed to delete model from store: %v", err)
 		}
 	})


### PR DESCRIPTION
Return untagged tags on delete to make it more similar to `docker image rm`.

This PR combined with local changes in https://github.com/docker/model-runner and https://github.com/docker/model-cli:
```
$ docker model tag ai/smollm2 dorin/smollm2
Model "ai/smollm2" tagged successfully with "index.docker.io/dorin/smollm2:latest"

$ docker model inspect ai/smollm2
{
    "id": "sha256:354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9",
    "tags": [
        "ai/smollm2",
        "index.docker.io/dorin/smollm2:latest"
    ],

$ docker model rm -f 354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9
Untagged: ai/smollm2
Untagged: index.docker.io/dorin/smollm2:latest
Model sha256:354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9 removed successfully
```