### PR TITLE
distribution client: return structured response for untagged and deleted models

### DIFF
--- a/internal/store/index.go
+++ b/internal/store/index.go
@@ -39,10 +39,10 @@ func (i Index) Tag(reference string, tag string) (Index, error) {
 	return result, nil
 }
 
-func (i Index) UnTag(tag string) Index {
+func (i Index) UnTag(tag string) (name.Tag, Index) {
 	tagRef, err := name.NewTag(tag)
 	if err != nil {
-		return Index{}
+		return name.Tag{}, Index{}
 	}
 
 	result := Index{
@@ -52,7 +52,7 @@ func (i Index) UnTag(tag string) Index {
 		result.Models = append(result.Models, entry.UnTag(tagRef))
 	}
 
-	return result
+	return tagRef, result
 }
 
 func (i Index) Find(reference string) (IndexEntry, int, bool) {

--- a/internal/store/index_test.go
+++ b/internal/store/index_test.go
@@ -146,12 +146,15 @@ func TestUntag(t *testing.T) {
 				},
 			},
 		}
-		idx = idx.UnTag("other-tag")
+		tag, idx := idx.UnTag("other-tag")
 		if len(idx.Models) != 2 {
 			t.Fatalf("Expected 2 models, got %d", len(idx.Models))
 		}
 		if len(idx.Models[0].Tags) != 1 {
 			t.Fatalf("Expected 1 tag, got %d", len(idx.Models[0].Tags))
+		}
+		if tag.String() != "other-tag" {
+			t.Fatalf("Expected tag 'other-tag', got '%s'", tag)
 		}
 	})
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -151,9 +151,12 @@ func TestStoreAPI(t *testing.T) {
 
 	// Test RemoveTags
 	t.Run("RemoveTags", func(t *testing.T) {
-		err := s.RemoveTags([]string{"api-model:api-v1.0"})
+		tags, err := s.RemoveTags([]string{"api-model:api-v1.0"})
 		if err != nil {
 			t.Fatalf("RemoveTags failed: %v", err)
+		}
+		if tags[0] != "index.docker.io/library/api-model:api-v1.0" {
+			t.Fatalf("Expected removed tag 'index.docker.io/library/api-model:api-v1.0', got '%s'", tags[0])
 		}
 
 		// Verify tag was removed from list
@@ -178,7 +181,7 @@ func TestStoreAPI(t *testing.T) {
 
 	// Test Delete
 	t.Run("Delete", func(t *testing.T) {
-		err := s.Delete("api-model:latest")
+		_, _, err := s.Delete("api-model:latest")
 		if err != nil {
 			t.Fatalf("Delete failed: %v", err)
 		}
@@ -192,7 +195,7 @@ func TestStoreAPI(t *testing.T) {
 
 	// Test Delete Non Existent Model
 	t.Run("Delete", func(t *testing.T) {
-		err := s.Delete("non-existent-model:latest")
+		_, _, err := s.Delete("non-existent-model:latest")
 		if !errors.Is(err, store.ErrModelNotFound) {
 			t.Fatalf("Expected ErrModelNotFound, got %v", err)
 		}
@@ -242,7 +245,7 @@ func TestStoreAPI(t *testing.T) {
 		}
 
 		// Delete the model
-		if err := s.Delete("blob-test:latest"); err != nil {
+		if _, _, err := s.Delete("blob-test:latest"); err != nil {
 			t.Fatalf("Delete failed: %v", err)
 		}
 
@@ -320,7 +323,7 @@ func TestStoreAPI(t *testing.T) {
 		}
 
 		// Delete the first model
-		if err := s.Delete("shared-model-1:latest"); err != nil {
+		if _, _, err := s.Delete("shared-model-1:latest"); err != nil {
 			t.Fatalf("Delete first model failed: %v", err)
 		}
 
@@ -368,7 +371,7 @@ func TestStoreAPI(t *testing.T) {
 		}
 
 		// Delete the second model
-		if err := s.Delete("shared-model-2:latest"); err != nil {
+		if _, _, err := s.Delete("shared-model-2:latest"); err != nil {
 			t.Fatalf("Delete second model failed: %v", err)
 		}
 


### PR DESCRIPTION
From https://github.com/docker/model-runner/pull/100#discussion_r2189603299.
Return structured response for untagged and deleted models.

https://github.com/docker/model-runner/pull/100 and https://github.com/docker/model-cli/pull/122 will require small changes once this PR is merged.

Without the required changes in the model-cli, this is the response I see:
```
$ MODEL_RUNNER_HOST=http://localhost:8080 docker model tag ai/smollm2 dorin/smollm2
Model "ai/smollm2" tagged successfully with "index.docker.io/dorin/smollm2:latest"

$ MODEL_RUNNER_HOST=http://localhost:8080 docker model inspect ai/smollm2
{
   "id": "sha256:354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9",
   "tags": [
       "ai/smollm2",
       "index.docker.io/dorin/smollm2:latest"
   ],
   "created": 1742816981,
   "config": {
       "format": "gguf",
       "quantization": "IQ2_XXS/Q4_K_M",
       "parameters": "361.82 M",
       "architecture": "llama",
       "size": "256.35 MiB"
   }
}

$ MODEL_RUNNER_HOST=http://localhost:8080 docker model rm dorin/smollm2
[{"Untagged":"index.docker.io/dorin/smollm2:latest"}]
Model dorin/smollm2 removed successfully

$ MODEL_RUNNER_HOST=http://localhost:8080 docker model tag ai/smollm2 dorin/smollm2
Model "ai/smollm2" tagged successfully with "index.docker.io/dorin/smollm2:latest"

$ MODEL_RUNNER_HOST=http://localhost:8080 docker model rm -f 354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9
[{"Untagged":"ai/smollm2"},{"Untagged":"index.docker.io/dorin/smollm2:latest"},{"Deleted":"sha256:354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9"}]
Model sha256:354bf30d0aa3af413d2aa5ae4f23c66d78980072d1e07a5b0d776e9606a2f0b9 removed successfully
```