### PR TITLE
Fix blob URL for ref with tag

### DIFF
--- a/registry/client.go
+++ b/registry/client.go
@@ -7,13 +7,14 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/docker/model-distribution/internal/progress"
-	"github.com/docker/model-distribution/types"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+
+	"github.com/docker/model-distribution/internal/progress"
+	"github.com/docker/model-distribution/types"
 )
 
 const (
@@ -122,7 +123,7 @@ func (c *Client) BlobURL(reference string, digest v1.Hash) (string, error) {
 	return fmt.Sprintf("%s://%s/v2/%s/blobs/%s",
 		ref.Context().Registry.Scheme(),
 		ref.Context().Registry.RegistryStr(),
-		ref.String(),
+		ref.Context().RepositoryStr(),
 		digest.String()), nil
 }
 


### PR DESCRIPTION
Fixes blob URL when ref includes explicit tag:

For example blob for model ref `emilycasey003/dummy:latest` get `https://index.docker.io/v2/emilycasey003/dummy/blobs/sha256:c7790a0a70161f1bfd441cf157313e9efb8fcd1f0831193101def035ead23b32` instead of `https://index.docker.io/v2/emilycasey003/dummy:latest/blobs/sha256:c7790a0a70161f1bfd441cf157313e9efb8fcd1f0831193101def035ead23b32`