### PR TITLE
Fix: do not parse arguments twice

### DIFF
--- a/cmd/mdltool/main.go
+++ b/cmd/mdltool/main.go
@@ -170,7 +170,6 @@ func cmdPackage(args []string) int {
 	fs.StringVar(&mmproj, "mmproj", "", "Path to Multimodal Projector file")
 	fs.StringVar(&file, "file", "", "Write archived model to the given file")
 	fs.StringVar(&tag, "tag", "", "Push model to the given registry tag")
-	fs.Parse(args)
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: model-distribution-tool package [OPTIONS] <path-to-gguf>\n\n")


### PR DESCRIPTION
Arguments are already parsed here: https://github.com/docker/model-distribution/blob/489d2c662c89361dd7c664140ee475e682721718/cmd/mdltool/main.go#L185